### PR TITLE
achieved CX Learning

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -786,15 +786,15 @@ def load_q_env_from_yaml_file(file_path: str):
     with open(file_path, "r") as f:
         config = yaml.safe_load(f)
 
-    low = np.array(config["ENV"]["ACTION_SPACE"]["LOW"])
-    high = np.array(config["ENV"]["ACTION_SPACE"]["HIGH"])
+    low = np.array(config["ENV"]["ACTION_SPACE"]["LOW"], dtype=np.float32)
+    high = np.array(config["ENV"]["ACTION_SPACE"]["HIGH"], dtype=np.float32)
     params = {
         "action_space": Box(
             low=low, high=high, shape=(config["ENV"]["N_ACTIONS"],), dtype=np.float32
         ),
         "observation_space": Box(
-            low=0.0,
-            high=1.0,
+            low=np.float32(0.0),
+            high=np.float32(1.0),
             shape=(config["ENV"]["OBSERVATION_SPACE"],),
             dtype=np.float32,
         ),
@@ -806,6 +806,7 @@ def load_q_env_from_yaml_file(file_path: str):
         "benchmark_cycle": config["ENV"]["BENCHMARK_CYCLE"],
         "target": {
             "register": config["TARGET"]["PHYSICAL_QUBITS"],
+        "training_with_cal": config["ENV"]["TRAINING_WITH_CAL"]
         },
     }
     if "GATE" in config["TARGET"]:

--- a/ppo.py
+++ b/ppo.py
@@ -180,6 +180,8 @@ def make_train_ppo(
                 )
                 next_obs = torch.Tensor(next_obs)
                 done = int(np.logical_or(terminated, truncated))
+                reward = torch.Tensor(reward)
+                rewards[step] = reward
 
                 batch_obs = torch.tile(next_obs, (batchsize, 1))
                 next_done = done * torch.ones_like(dones[0])
@@ -188,7 +190,7 @@ def make_train_ppo(
 
                 # print(f"global_step={global_step}, episodic_return={np.mean(reward)}")
                 writer.add_scalar(
-                    "charts/episodic_return", np.mean(reward), global_step
+                    "charts/episodic_return", np.mean(reward.numpy()), global_step
                 )
                 writer.add_scalar("charts/episodic_length", num_steps, global_step)
 
@@ -288,7 +290,14 @@ def make_train_ppo(
             if print_debug:
                 print("mean", mean_action[0])
                 print("sigma", std_action[0])
-                print("Average return:", np.mean(env.reward_history, axis=1)[-1])
+                print("DFE Rewards Mean:", np.mean(env.reward_history, axis=1)[-1])
+                print(
+                    "DFE Rewards standard dev", np.std(env.reward_history, axis=1)[-1]
+                )
+                print("Returns Mean:", np.mean(b_returns.numpy()))
+                print("Returns standard dev", np.std(b_returns.numpy()))
+                print("Advantages Mean:", np.mean(b_advantages.numpy()))
+                print("Advantages standard dev", np.std(b_advantages.numpy()))
                 # print(np.mean(env.reward_history, axis =1)[-1])
                 # print("Circuit fidelity:", env.circuit_fidelity_history[-1])
 

--- a/ppo.py
+++ b/ppo.py
@@ -3,6 +3,7 @@ import numpy as np
 from typing import Optional, Dict
 import tqdm
 import warnings
+from IPython.display import clear_output
 
 # Torch imports for building RL agent and framework
 from gymnasium.spaces import Box
@@ -130,7 +131,11 @@ def make_train_ppo(
         agent.parameters(), lr=lr, eps=optim_eps
     )
 
-    def train(total_updates: int, print_debug: Optional[bool] = True):
+    def train(
+        total_updates: int,
+        print_debug: Optional[bool] = True,
+        num_prints: Optional[int] = 40,
+    ):
         env.clear_history()
         start = time.time()
         global_step = 0
@@ -286,6 +291,9 @@ def make_train_ppo(
                 print("Average return:", np.mean(env.reward_history, axis=1)[-1])
                 # print(np.mean(env.reward_history, axis =1)[-1])
                 # print("Circuit fidelity:", env.circuit_fidelity_history[-1])
+
+                if global_step % num_prints == 0:
+                    clear_output(wait=True)
 
             # TRY NOT TO MODIFY: record rewards for plotting purposes
             writer.add_scalar(

--- a/qconfig.py
+++ b/qconfig.py
@@ -121,4 +121,5 @@ class QEnvConfig:
     c_factor: float = 0.5
     benchmark_cycle: int = 1
     seed: int = 1234
+    training_with_cal: bool = True
     device: Optional[torch.device] = None

--- a/quantumenvironment.py
+++ b/quantumenvironment.py
@@ -306,9 +306,11 @@ class QuantumEnvironment(Env):
         self.n_shots = training_config.n_shots
         self.sampling_Pauli_space = training_config.sampling_Paulis
         self.c_factor = training_config.c_factor
+        self.training_with_cal = training_config.training_with_cal
         self.batch_size = training_config.batch_size
         self._parameters = ParameterVector("a", training_config.action_space.shape[-1])
         self._tgt_instruction_counts = 1  # Number of instructions to calibrate
+        self._reward_check_max = 1.1
         if isinstance(self.training_config.backend_config, QiskitConfig):
             self._config_type = "qiskit"
             if not isinstance(self.training_config.backend_config, QiskitConfig):
@@ -396,6 +398,7 @@ class QuantumEnvironment(Env):
                 f"The Training Config observation space: {self.observation_space.shape} does not "
                 f"match the Environment observation shape: {example_obs.shape}"
             )
+        self.check_reward()
 
     def reset(
         self,
@@ -446,6 +449,7 @@ class QuantumEnvironment(Env):
                 False,
                 self._get_info(),
             )
+        action *= np.pi
         params, batch_size = np.array(action), action.shape[0]
         if batch_size != self.batch_size:
             raise ValueError(f"Batch size mismatch: {batch_size} != {self.batch_size} ")
@@ -461,6 +465,19 @@ class QuantumEnvironment(Env):
         reward = -np.log(1.0 - reward)
 
         return self._get_obs(), reward, terminated, False, self._get_info()
+
+    def check_reward(self):
+        if self.training_with_cal:
+            sample_action = np.zeros(self.action_space.shape)
+            batch_action = np.tile(sample_action, (self.batch_size, 1))
+            batch_rewards = self.perform_action(batch_action)
+            mean_reward = np.mean(batch_rewards)
+            if mean_reward > self._reward_check_max:
+                raise ValueError(
+                    f"Current Mean Reward with Config Vals is {mean_reward}, try a C Factor around {self.c_factor / mean_reward}"
+                )
+        else:
+            pass
 
     def episode_length(self, global_step: int):
         assert (

--- a/template_configurations/agent_config.yaml
+++ b/template_configurations/agent_config.yaml
@@ -1,18 +1,18 @@
 RUN_NAME: "test" # Name of the run
 OPTIMIZER: "adam" # Optimizer for the policy network
 NUM_UPDATES: 1 # Number of policy updates
-N_EPOCHS: 12 # Number of epochs for each policy update
-MINIBATCH_SIZE: 24 # Number of samples per mini-batch
-LR: 0.01 # Learning rate
+N_EPOCHS: 8 # Number of epochs for each policy update
+MINIBATCH_SIZE: 32 # Number of samples per mini-batch
+LR: 0.001 # Learning rate
 GAMMA: 0.99 # Discount factor
 GAE_LAMBDA: 0.95 # Lambda coefficient for Generalized Advantage Estimation
-ENT_COEF: 0.01 # Entropy coefficient
+ENT_COEF: 0.0 # Entropy coefficient
 V_COEF: 0.5 # Value (critic) function coefficient
-GRADIENT_CLIP: 5. # Gradient clipping
+GRADIENT_CLIP: 0.5 # Gradient clipping
 CLIP_VALUE_LOSS: True # Whether to clip value loss
 CLIP_VALUE_COEF: 0.2 # Clipping coefficient for value loss
 CLIP_RATIO: 0.2 # Clipping ratio for PPO
-N_UNITS: [ 64, 64 ] # Number of units in hidden layers
+N_UNITS: [64, 64] # Number of units in hidden layers
 ACTIVATION: "tanh" # Activation functions
 INCLUDE_CRITIC: True # Whether to include critic network within ActorCritic model
 NORMALIZE_ADVANTAGE: True # Whether to normalize advantage

--- a/template_configurations/qiskit/gate_level_learning.ipynb
+++ b/template_configurations/qiskit/gate_level_learning.ipynb
@@ -1,0 +1,673 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"KMP_DUPLICATE_LIB_OK\"] = \"True\"\n",
+    "import sys\n",
+    "\n",
+    "module_path = os.path.abspath(\n",
+    "    os.path.join(\n",
+    "        \"/Users/chatt07/Desktop/cqt_env/Quantum_Optimal_Control\"\n",
+    "    )\n",
+    ")\n",
+    "if module_path not in sys.path:\n",
+    "    sys.path.append(module_path)\n",
+    "sys.path.append(\n",
+    "    os.path.abspath(\n",
+    "        os.path.join(\n",
+    "            \"/Users/chatt07/Desktop/cqt_env/Quantum_Optimal_Control\"\n",
+    "        )\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/chatt07/Desktop/cqt_env/lib/python3.9/site-packages/jaxtyping/__init__.py:221: UserWarning: jaxtyping version >=0.2.23 should be used with Equinox version >=0.11.1\n",
+      "  warnings.warn(\n",
+      "/Users/chatt07/Desktop/cqt_env/lib/python3.9/site-packages/qiskit_dynamics/dispatch/backends/jax.py:34: UserWarning: The functionality in the perturbation module of Qiskit Dynamics requires a JAX version <= 0.4.6, due to a bug in JAX versions > 0.4.6. For versions 0.4.4, 0.4.5, and 0.4.6, using the perturbation module functionality requires setting os.environ['JAX_JIT_PJIT_API_MERGE'] = '0' before importing JAX or Dynamics.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "from template_configurations import gate_q_env_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quantumenvironment import QuantumEnvironment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SparsePauliOp(['II', 'IZ', 'ZI', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j, -0.25+0.j,  0.25+0.j])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "QuantumEnvironment composed of 2 qubits, \n",
+       "Defined target: gate (Instruction(name='cx', num_qubits=2, num_clbits=0, params=[]))\n",
+       "Physical qubits: [0, 1]\n",
+       "Backend: <qiskit.providers.fake_provider.backends.jakarta.fake_jakarta.FakeJakartaV2 object at 0x7fb856ad8ee0>,\n",
+       "Abstraction level: circuit,\n",
+       "Run options: N_shots (1), Sampling_Pauli_space (100), \n",
+       "Batchsize: 256, "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "q_env = QuantumEnvironment(gate_q_env_config)\n",
+    "q_env"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "with open(\n",
+    "        \"/Users/chatt07/Desktop/cqt_env/Quantum_Optimal_Control/template_configurations/agent_config.yaml\",\n",
+    "        \"r\",\n",
+    ") as f:\n",
+    "    agent_config = yaml.safe_load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ppo import make_train_ppo\n",
+    "\n",
+    "ppo_agent = make_train_ppo(agent_config, q_env)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r 96%|█████████▌| 480/500 [07:26<00:14,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SparsePauliOp(['II', 'IZ', 'XI', 'XZ'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 96%|█████████▌| 481/500 [07:27<00:13,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0266,  0.0615, -0.0665,  0.0001, -0.0136, -0.0118,  0.0070])\n",
+      "sigma tensor([0.0142, 0.0354, 0.0345, 0.0141, 0.0163, 0.0191, 0.0134])\n",
+      "DFE Rewards Mean: 0.9962172545873591\n",
+      "DFE Rewards standard dev 0.008793907469772001\n",
+      "Returns Mean: 8.134765\n",
+      "Returns standard dev 4.15796\n",
+      "Advantages Mean: 0.28965986\n",
+      "Advantages standard dev 4.15796\n",
+      "SparsePauliOp(['II', 'XY', 'YZ', 'ZX'],\n",
+      "              coeffs=[ 0.25+0.j,  0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 96%|█████████▋| 482/500 [07:28<00:13,  1.33it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0166,  0.0459, -0.0630, -0.0068, -0.0006, -0.0238, -0.0098])\n",
+      "sigma tensor([0.0143, 0.0181, 0.0179, 0.0126, 0.0148, 0.0182, 0.0128])\n",
+      "DFE Rewards Mean: 0.9931207521523903\n",
+      "DFE Rewards standard dev 0.011119434332815745\n",
+      "Returns Mean: 7.086011\n",
+      "Returns standard dev 3.9365819\n",
+      "Advantages Mean: -0.32549363\n",
+      "Advantages standard dev 3.9365819\n",
+      "SparsePauliOp(['II', 'IZ', 'ZI', 'ZZ'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 483/500 [07:28<00:12,  1.34it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0287,  0.0525, -0.0620,  0.0150, -0.0250, -0.0127,  0.0035])\n",
+      "sigma tensor([0.0139, 0.0408, 0.0439, 0.0147, 0.0168, 0.0200, 0.0153])\n",
+      "DFE Rewards Mean: 0.9932350026324641\n",
+      "DFE Rewards standard dev 0.013040177370781404\n",
+      "Returns Mean: 7.786288\n",
+      "Returns standard dev 4.3588796\n",
+      "Advantages Mean: -0.16090621\n",
+      "Advantages standard dev 4.3588796\n",
+      "SparsePauliOp(['II', 'XX', 'YY', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j,  0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 484/500 [07:29<00:11,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0207,  0.0482, -0.0611,  0.0078, -0.0190, -0.0223, -0.0126])\n",
+      "sigma tensor([0.0160, 0.0254, 0.0273, 0.0153, 0.0169, 0.0204, 0.0146])\n",
+      "DFE Rewards Mean: 0.9931592449657876\n",
+      "DFE Rewards standard dev 0.011663718606528413\n",
+      "Returns Mean: 7.132702\n",
+      "Returns standard dev 3.9400046\n",
+      "Advantages Mean: -0.20097256\n",
+      "Advantages standard dev 3.9400046\n",
+      "SparsePauliOp(['II', 'IZ', 'YI', 'YZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j, -0.25+0.j,  0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 485/500 [07:30<00:11,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0276,  0.0543, -0.0609,  0.0079, -0.0212, -0.0194, -0.0075])\n",
+      "sigma tensor([0.0159, 0.0284, 0.0252, 0.0150, 0.0166, 0.0225, 0.0140])\n",
+      "DFE Rewards Mean: 0.9937630506045247\n",
+      "DFE Rewards standard dev 0.010500286146812452\n",
+      "Returns Mean: 7.2017217\n",
+      "Returns standard dev 3.962941\n",
+      "Advantages Mean: -0.13325977\n",
+      "Advantages standard dev 3.962941\n",
+      "SparsePauliOp(['II', 'IX', 'XI', 'XX'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 486/500 [07:31<00:10,  1.33it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0200,  0.0463, -0.0625,  0.0062, -0.0216, -0.0251, -0.0156])\n",
+      "sigma tensor([0.0170, 0.0210, 0.0211, 0.0158, 0.0162, 0.0196, 0.0128])\n",
+      "DFE Rewards Mean: 0.9903478820642275\n",
+      "DFE Rewards standard dev 0.014228632101969181\n",
+      "Returns Mean: 6.927187\n",
+      "Returns standard dev 4.033869\n",
+      "Advantages Mean: -0.20273516\n",
+      "Advantages standard dev 4.0338683\n",
+      "SparsePauliOp(['II', 'XX', 'YY', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j,  0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 97%|█████████▋| 487/500 [07:31<00:09,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0239,  0.0574, -0.0671,  0.0083, -0.0263, -0.0248, -0.0121])\n",
+      "sigma tensor([0.0166, 0.0213, 0.0183, 0.0148, 0.0146, 0.0193, 0.0114])\n",
+      "DFE Rewards Mean: 0.9934460385580604\n",
+      "DFE Rewards standard dev 0.009787617173509008\n",
+      "Returns Mean: 7.1900663\n",
+      "Returns standard dev 3.97896\n",
+      "Advantages Mean: 0.08895011\n",
+      "Advantages standard dev 3.97896\n",
+      "SparsePauliOp(['II', 'IZ', 'XI', 'XZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 488/500 [07:32<00:08,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0319,  0.0583, -0.0629,  0.0122, -0.0275, -0.0241, -0.0099])\n",
+      "sigma tensor([0.0160, 0.0241, 0.0203, 0.0136, 0.0141, 0.0202, 0.0106])\n",
+      "DFE Rewards Mean: 0.9912981734433582\n",
+      "DFE Rewards standard dev 0.011899657892991154\n",
+      "Returns Mean: 6.7223005\n",
+      "Returns standard dev 3.881288\n",
+      "Advantages Mean: -0.60662854\n",
+      "Advantages standard dev 3.881288\n",
+      "SparsePauliOp(['II', 'IZ', 'YI', 'YZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j, -0.25+0.j,  0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 489/500 [07:33<00:08,  1.37it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0333,  0.0552, -0.0657,  0.0020, -0.0216, -0.0211, -0.0121])\n",
+      "sigma tensor([0.0155, 0.0224, 0.0194, 0.0136, 0.0153, 0.0181, 0.0110])\n",
+      "DFE Rewards Mean: 0.9937797658613524\n",
+      "DFE Rewards standard dev 0.011157230174069938\n",
+      "Returns Mean: 7.4686546\n",
+      "Returns standard dev 4.1149054\n",
+      "Advantages Mean: 0.33232605\n",
+      "Advantages standard dev 4.114906\n",
+      "SparsePauliOp(['II', 'IZ', 'YI', 'YZ'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 490/500 [07:34<00:07,  1.37it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0319,  0.0746, -0.0696,  0.0036, -0.0219, -0.0106, -0.0076])\n",
+      "sigma tensor([0.0140, 0.0292, 0.0262, 0.0141, 0.0178, 0.0175, 0.0125])\n",
+      "DFE Rewards Mean: 0.9953243096879595\n",
+      "DFE Rewards standard dev 0.00913642980725518\n",
+      "Returns Mean: 7.533272\n",
+      "Returns standard dev 3.9511285\n",
+      "Advantages Mean: 0.07616256\n",
+      "Advantages standard dev 3.9511287\n",
+      "SparsePauliOp(['II', 'IZ', 'ZI', 'ZZ'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 491/500 [07:34<00:06,  1.37it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0318,  0.0770, -0.0676,  0.0070, -0.0183, -0.0018, -0.0010])\n",
+      "sigma tensor([0.0159, 0.0338, 0.0348, 0.0135, 0.0181, 0.0188, 0.0123])\n",
+      "DFE Rewards Mean: 0.9937738663975431\n",
+      "DFE Rewards standard dev 0.010681141587996422\n",
+      "Returns Mean: 7.46487\n",
+      "Returns standard dev 4.077412\n",
+      "Advantages Mean: -0.15825802\n",
+      "Advantages standard dev 4.077412\n",
+      "SparsePauliOp(['II', 'IZ', 'YI', 'YZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j, -0.25+0.j,  0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 492/500 [07:35<00:05,  1.38it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0175,  0.0662, -0.0640, -0.0003, -0.0085, -0.0044, -0.0105])\n",
+      "sigma tensor([0.0162, 0.0213, 0.0235, 0.0128, 0.0185, 0.0197, 0.0116])\n",
+      "DFE Rewards Mean: 0.9962018199904501\n",
+      "DFE Rewards standard dev 0.007866232487770117\n",
+      "Returns Mean: 8.072056\n",
+      "Returns standard dev 4.1043634\n",
+      "Advantages Mean: 0.93399704\n",
+      "Advantages standard dev 4.1043634\n",
+      "SparsePauliOp(['II', 'IZ', 'ZI', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 99%|█████████▊| 493/500 [07:36<00:05,  1.38it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0198,  0.0737, -0.0662,  0.0027, -0.0051,  0.0001, -0.0109])\n",
+      "sigma tensor([0.0157, 0.0255, 0.0279, 0.0131, 0.0184, 0.0175, 0.0114])\n",
+      "DFE Rewards Mean: 0.9965537017360274\n",
+      "DFE Rewards standard dev 0.007494204303556509\n",
+      "Returns Mean: 8.214684\n",
+      "Returns standard dev 4.103974\n",
+      "Advantages Mean: 0.8486594\n",
+      "Advantages standard dev 4.103974\n",
+      "SparsePauliOp(['II', 'XX', 'YY', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j,  0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 99%|█████████▉| 494/500 [07:36<00:04,  1.38it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0105,  0.0737, -0.0682, -0.0060, -0.0009, -0.0029, -0.0204])\n",
+      "sigma tensor([0.0151, 0.0201, 0.0221, 0.0127, 0.0186, 0.0170, 0.0115])\n",
+      "DFE Rewards Mean: 0.9944848418424128\n",
+      "DFE Rewards standard dev 0.00999192535988965\n",
+      "Returns Mean: 7.68702\n",
+      "Returns standard dev 4.1046414\n",
+      "Advantages Mean: 0.2906214\n",
+      "Advantages standard dev 4.1046414\n",
+      "SparsePauliOp(['II', 'XX', 'YY', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j,  0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 99%|█████████▉| 495/500 [07:37<00:03,  1.36it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0073,  0.0701, -0.0634, -0.0051, -0.0017,  0.0003, -0.0160])\n",
+      "sigma tensor([0.0145, 0.0175, 0.0193, 0.0115, 0.0194, 0.0153, 0.0129])\n",
+      "DFE Rewards Mean: 0.9966548879475028\n",
+      "DFE Rewards standard dev 0.008510116722771187\n",
+      "Returns Mean: 8.429539\n",
+      "Returns standard dev 4.2419553\n",
+      "Advantages Mean: 0.8566511\n",
+      "Advantages standard dev 4.2419553\n",
+      "SparsePauliOp(['II', 'IZ', 'ZI', 'ZZ'],\n",
+      "              coeffs=[ 0.25+0.j, -0.25+0.j, -0.25+0.j,  0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 99%|█████████▉| 496/500 [07:38<00:02,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0089,  0.0666, -0.0614,  0.0007,  0.0023,  0.0005, -0.0109])\n",
+      "sigma tensor([0.0146, 0.0246, 0.0248, 0.0123, 0.0193, 0.0149, 0.0143])\n",
+      "DFE Rewards Mean: 0.9971760389475258\n",
+      "DFE Rewards standard dev 0.00685880725715888\n",
+      "Returns Mean: 8.612041\n",
+      "Returns standard dev 4.1521163\n",
+      "Advantages Mean: 0.7365921\n",
+      "Advantages standard dev 4.152116\n",
+      "SparsePauliOp(['II', 'XY', 'YZ', 'ZX'],\n",
+      "              coeffs=[ 0.25+0.j,  0.25+0.j,  0.25+0.j, -0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 99%|█████████▉| 497/500 [07:39<00:02,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0020,  0.0576, -0.0666,  0.0009,  0.0128, -0.0036, -0.0154])\n",
+      "sigma tensor([0.0148, 0.0152, 0.0165, 0.0131, 0.0158, 0.0138, 0.0124])\n",
+      "DFE Rewards Mean: 0.9966990918338238\n",
+      "DFE Rewards standard dev 0.007773262458079496\n",
+      "Returns Mean: 8.202747\n",
+      "Returns standard dev 4.123061\n",
+      "Advantages Mean: 0.5574889\n",
+      "Advantages standard dev 4.123061\n",
+      "SparsePauliOp(['II', 'XY', 'YX', 'ZZ'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████▉| 498/500 [07:39<00:01,  1.35it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([-0.0001,  0.0879, -0.0815,  0.0044,  0.0057,  0.0065, -0.0284])\n",
+      "sigma tensor([0.0155, 0.0246, 0.0227, 0.0134, 0.0204, 0.0181, 0.0134])\n",
+      "DFE Rewards Mean: 0.9932830478399604\n",
+      "DFE Rewards standard dev 0.012383277722323803\n",
+      "Returns Mean: 7.481123\n",
+      "Returns standard dev 4.190248\n",
+      "Advantages Mean: -0.44333202\n",
+      "Advantages standard dev 4.1902485\n",
+      "SparsePauliOp(['II', 'IZ', 'XI', 'XZ'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████▉| 499/500 [07:40<00:00,  1.34it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([ 0.0052,  0.0876, -0.0712,  0.0115,  0.0001,  0.0119, -0.0199])\n",
+      "sigma tensor([0.0150, 0.0377, 0.0357, 0.0134, 0.0223, 0.0191, 0.0166])\n",
+      "DFE Rewards Mean: 0.9961557729506494\n",
+      "DFE Rewards standard dev 0.00797154953539408\n",
+      "Returns Mean: 8.036349\n",
+      "Returns standard dev 4.065026\n",
+      "Advantages Mean: -0.039584704\n",
+      "Advantages standard dev 4.065026\n",
+      "SparsePauliOp(['II', 'XX', 'YZ', 'ZY'],\n",
+      "              coeffs=[0.25+0.j, 0.25+0.j, 0.25+0.j, 0.25+0.j])\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 500/500 [07:41<00:00,  1.08it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean tensor([-0.0074,  0.0791, -0.0789,  0.0088,  0.0105,  0.0084, -0.0310])\n",
+      "sigma tensor([0.0156, 0.0248, 0.0221, 0.0141, 0.0192, 0.0169, 0.0166])\n",
+      "DFE Rewards Mean: 0.9935157707583915\n",
+      "DFE Rewards standard dev 0.011584994200080558\n",
+      "Returns Mean: 7.5456777\n",
+      "Returns standard dev 4.21722\n",
+      "Advantages Mean: -0.21011832\n",
+      "Advantages standard dev 4.21722\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ppo_agent(total_updates=500, print_debug=True, num_prints=40)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkgAAAHHCAYAAABEEKc/AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAClDElEQVR4nOzdeXwT1doH8F+SNkn3faWlhbIUBYoUqAXZq1W4KIiIiAoV8eIFF/qqgLK6AMoVQURxQVAUBS6Ism+yyA6FytqyUyjdWNpC9ybn/aPNdGYykyZp2rTl+X4+VTqZTE4maebJc55zjoIxxkAIIYQQQjhKezeAEEIIIaS+oQCJEEIIIUSEAiRCCCGEEBEKkAghhBBCRChAIoQQQggRoQCJEEIIIUSEAiRCCCGEEBEKkAghhBBCRChAIoQQQggRoQCJEEJEevXqhV69etm7GYQQO6IAiZD7zMWLF/Hvf/8bzZs3h1arhbu7O7p164b58+ejqKgIAHDmzBmo1WokJCQY3T83NxdBQUGIiYmBXq+XfZxdu3ZBoVDgf//7X609l8ZKp9NhyZIl6NWrF7y9vaHRaBAeHo6EhAQcPXrU3s0j5L7gYO8GEELqzoYNGzBkyBBoNBq89NJLaNu2LUpLS7F371688847OH36NL799ls88MADeOeddzBz5kyMHDkSPXv25I4xceJE5OTkYNOmTVAqG+d3rK1bt9rtsYuKivD0009j8+bN6NGjB9577z14e3vjypUrWLlyJX788UekpaUhJCTEbm0k5L7ACCH3hUuXLjFXV1cWGRnJbty4YXT7+fPn2bx587jfi4qKWEREBGvdujUrKSlhjDG2f/9+plAoWGJiYrWPt3PnTgaArVq1ynZPwgo6nY4VFRXZtQ2WGDt2LAPAPv/8c6PbysvL2Zw5c9i1a9dq/DgN7bwQUtcoQCLkPjFmzBgGgO3bt8/s+2zdupUBYNOnT2elpaWsbdu2rGnTpuzevXvV3tfcAOnOnTvszTffZCEhIUytVrOIiAg2e/ZsptPpBPvNmTOHxcbGMm9vb6bValnHjh0ljw2AjR07lv3888/sgQceYA4ODuz3339nS5YsYQDY3r172fjx45mvry9zdnZmAwcOZNnZ2YJj9OzZk/Xs2dPouaxYsYJ99NFHrEmTJkyj0bA+ffqw8+fPG7Xhyy+/ZM2aNWNarZZ17tyZ7dmzx+iYUq5du8YcHBzYo48+anI/gxEjRrCwsDCj7dOmTWPi779S52XlypXMy8uLjRw50ugYeXl5TKPRsP/7v//jthUXF7OpU6eyiIgIplarWUhICHvnnXdYcXGxWe0lpCGhLjZC7hPr1q1D8+bN0bVrV7Pv8+ijj2LYsGGYNWsWbty4gVOnTuGPP/6Ai4uLTdpUWFiInj17Ij09Hf/+97/RtGlT7N+/H5MmTUJGRgbmzZvH7Tt//nw8+eSTGD58OEpLS/Hbb79hyJAhWL9+Pfr37y847l9//YWVK1di3Lhx8PX1RXh4OJKTkwEAr7/+Ory8vDBt2jRcuXIF8+bNw7hx47BixYpq2zt79mwolUq8/fbbyMvLw6efforhw4fj0KFD3D5ff/01xo0bh+7du2P8+PG4cuUKBg4cCC8vr2q7xTZt2oTy8nK8+OKL5p9EC4jPS8uWLTFo0CCsWbMG33zzDdRqNbfv2rVrUVJSgueeew4AoNfr8eSTT2Lv3r149dVX0aZNG5w8eRKff/45zp07h7Vr19ZKmwmxG3tHaISQ2peXl8cAsKeeesri+2ZmZjIvLy8GgA0cONDs+5mTQfrwww+Zi4sLO3funGD7xIkTmUqlYmlpady2wsJCwT6GjFafPn0E2wEwpVLJTp8+LdhuyCDFxcUxvV7PbR8/fjxTqVQsNzeX2yaXQWrTpg3X3cgYY/Pnz2cA2MmTJxljjJWUlDAfHx/WuXNnVlZWxu23dOlSBqDaDNL48eMZAHb8+HGT+xlYmkGSOi9btmxhANi6desE2/v168eaN2/O/b5s2TKmVCrZ33//Ldhv0aJFFmcmCWkIGmeFJSFEID8/HwDg5uZm8X2dnZ3h7OwMAHjsscds2q5Vq1ahe/fu8PLyws2bN7mfuLg46HQ67Nmzh9vXycmJ+/edO3eQl5eH7t2749ixY0bH7dmzJx544AHJx3z11VehUCi437t37w6dToerV69W296EhARBlqV79+4AgEuXLgEAjh49ilu3bmH06NFwcKhK0A8fPhxeXl7VHr8mr5M5pM5Lnz594OvrK8ig3blzB9u2bcPQoUO5batWrUKbNm0QGRkpeK369OkDANi5c2ettJkQe6EuNkLuA+7u7gCAu3fvWnzf999/H5mZmWjTpg2mTZuG5557zqyLvTnOnz+PEydOwM/PT/L27Oxs7t/r16/HRx99hOTkZJSUlHDb+cGOQbNmzWQfs2nTpoLfDc/lzp071ba3uvsagqwWLVoI9nNwcEB4eHi1x6/J62QOqfPi4OCAwYMHY/ny5SgpKYFGo8GaNWtQVlYmCJDOnz+Ps2fPmvVaEdIYUIBEyH3A3d0dwcHBOHXqlEX3O3r0KBYuXIg33ngDCQkJiI6OxoQJE/Dtt9/apF16vR6PPvoo3n33XcnbW7VqBQD4+++/8eSTT6JHjx746quvEBQUBEdHRyxZsgTLly83uh8/2ySmUqkktzPGqm1vTe5rjsjISADAyZMn0aFDh2r3lwoOgYp5lKTInZfnnnsO33zzDTZt2oSBAwdi5cqViIyMRFRUFLePXq9Hu3btMHfuXMljhIaGVtteQhoSCpAIuU/861//wrfffosDBw4gNja22v11Oh1effVVBAcH44MPPoCbmxvefPNNzJ07FwkJCWYdozoRERG4d+8e4uLiTO63evVqaLVabNmyBRqNhtu+ZMmSGrfBlsLCwgAAFy5cQO/evbnt5eXluHLlCtq3b2/y/k888QRUKhV+/vlnswq1vby8kJuba7TdnO5Cvh49eiAoKAgrVqzAI488gr/++gvvv/++YJ+IiAj8888/6Nu3r2xgRkhjQjVIhNwn3n33Xbi4uOCVV15BVlaW0e0XL17E/Pnzud+/+OILHD9+HF988QVXEzNjxgyEhIRgzJgxKC8vr3Gbnn32WRw4cABbtmwxui03N5d7DJVKBYVCIciMXLlypd6NnOrUqRN8fHzw3XffCc7PL7/8YlYXXmhoKEaPHo2tW7diwYIFRrfr9Xp89tlnuH79OoCKoCUvLw8nTpzg9snIyMDvv/9uUbuVSiWeeeYZrFu3DsuWLUN5ebmgew2oeK3S09Px3XffGd2/qKgIBQUFFj0mIfUdZZAIuU9ERERg+fLlGDp0KNq0aSOYSXv//v1YtWoVRo4cCQC4du0apk6digEDBmDQoEHcMVxcXDB//nw8/fTTmD9/Pv7v//6v2sddvXo1UlJSjLaPGDEC77zzDv7880/861//wsiRIxEdHY2CggKcPHkS//vf/3DlyhX4+vqif//+mDt3Lh5//HE8//zzyM7OxsKFC9GiRQtBcGBvarUa06dPx+uvv44+ffrg2WefxZUrV7B06VJERESYlXn57LPPcPHiRbzxxhtYs2YN/vWvf8HLywtpaWlYtWoVUlJSuKH3zz33HCZMmIBBgwbhjTfeQGFhIb7++mu0atVKsnjdlKFDh2LBggWYNm0a2rVrhzZt2ghuf/HFF7Fy5UqMGTMGO3fuRLdu3aDT6ZCSkoKVK1diy5Yt6NSpk0WPSUi9Zu9hdISQunXu3Dk2evRoFh4eztRqNXNzc2PdunVjCxYs4Cb8e+qpp5iLiwu7evWq5DH+9a9/MVdXV8EwfDHD0Hi5H8Nw8bt377JJkyaxFi1aMLVazXx9fVnXrl3Zf//7X1ZaWsodb/Hixaxly5ZMo9GwyMhItmTJEpMTIooZhvkfOXJEsp07d+7ktskN8xdPWXD58mUGgC1ZskSw/YsvvmBhYWFMo9GwLl26sH379rHo6Gj2+OOPy54vvvLycvb999+z7t27Mw8PD+bo6MjCwsJYQkKC0RQAW7duZW3btmVqtZq1bt2a/fzzzxadFwO9Xs9CQ0MZAPbRRx9J7lNaWso++eQT9uCDDzKNRsO8vLxYdHQ0mzFjBsvLyzPruRHSUCgYs1F1ISGEEEl6vR5+fn54+umnJbuoCCH1D9UgEUKIDRUXFxuNavvpp59w+/Zt9OrVyz6NIoRYjDJIhBBiQ7t27cL48eMxZMgQ+Pj44NixY1i8eDHatGmDpKQkwUSThJD6i4q0CSHEhsLDwxEaGoovvvgCt2/fhre3N1566SXMnj2bgiNCGhDKIBFCCCGEiFANEiGEEEKICAVIhBBCCCEiVINkJb1ejxs3bsDNzY2m3SeEEEIaCMYY7t69i+DgYCiV8nkiCpCsdOPGDVqckRBCCGmgrl27hpCQENnbKUCykmFtqmvXrsHd3d3OrSGEEEKIOfLz8xEaGspdx+VQgGQlQ7eau7s7BUiEEEJIA1NdeQwVaRNCCCGEiFCARAghhBAiQgESIYQQQogIBUiEEEIIISIUIBFCCCGEiFCARAghhBAiYtcAac+ePRgwYACCg4OhUCiwdu3aau+za9cudOzYERqNBi1atMDSpUuN9lm4cCHCw8Oh1WoRExODw4cPC24vLi7G2LFj4ePjA1dXVwwePBhZWVk2elaEEEIIaejsGiAVFBQgKioKCxcuNGv/y5cvo3///ujduzeSk5Px1ltv4ZVXXsGWLVu4fVasWIHExERMmzYNx44dQ1RUFOLj45Gdnc3tM378eKxbtw6rVq3C7t27cePGDTz99NM2f36EEEIIaZgUjDFm70YAFRM2/f777xg4cKDsPhMmTMCGDRtw6tQpbttzzz2H3NxcbN68GQAQExODzp0748svvwRQsWZaaGgoXn/9dUycOBF5eXnw8/PD8uXL8cwzzwAAUlJS0KZNGxw4cAAPP/ywWe3Nz8+Hh4cH8vLyaKJIQgghpIEw9/rdoGqQDhw4gLi4OMG2+Ph4HDhwAABQWlqKpKQkwT5KpRJxcXHcPklJSSgrKxPsExkZiaZNm3L7SCkpKUF+fr7ghxBCCCGNU4MKkDIzMxEQECDYFhAQgPz8fBQVFeHmzZvQ6XSS+2RmZnLHUKvV8PT0lN1HyqxZs+Dh4cH90EK1hBBCSOPVoAIke5o0aRLy8vK4n2vXrtm7SYQQQgipJQ1qsdrAwECj0WZZWVlwd3eHk5MTVCoVVCqV5D6BgYHcMUpLS5GbmyvIIvH3kaLRaKDRaGz3ZAghjVa5Tg8HFX3/JKQha1B/wbGxsdixY4dg27Zt2xAbGwsAUKvViI6OFuyj1+uxY8cObp/o6Gg4OjoK9klNTUVaWhq3DyGE8J3NyEfO3RKz9j18+TZaTd6EJfsu2+zx75WU2+xYde1eSTkOXroFvb5ejAdqsHR6hnoypuq+YdcA6d69e0hOTkZycjKAimH8ycnJSEtLA1DRrfXSSy9x+48ZMwaXLl3Cu+++i5SUFHz11VdYuXIlxo8fz+2TmJiI7777Dj/++CPOnj2L1157DQUFBUhISAAAeHh4YNSoUUhMTMTOnTuRlJSEhIQExMbGmj2CjRBSO8p0ekxeexKbTmbYuymcC9n38MT8v9H54+34fNs5pGbeNbn/gr/OQ8+AGevO2OTxfz2chnbTt2D9iRuSt9f3i+boH4/iuW8PYtnBq9y2fRdu4lyW6fPYkOQWluLgpVvca1FYWo4XFx/CV7suWH3M5Gu52H0uB6XlehxPu4M2Uzdj5sazgn0YY/jPL0l47eckq98H57Pu4pPNKfh2z0UUlJTj+p1CPPP1/hq13Ro5d0vw3y2pOJWeV6ePa4pdu9iOHj2K3r17c78nJiYCAEaMGIGlS5ciIyODC5YAoFmzZtiwYQPGjx+P+fPnIyQkBN9//z3i4+O5fYYOHYqcnBxMnToVmZmZ6NChAzZv3iwo3P7888+hVCoxePBglJSUID4+Hl999VUdPGNCGg/GGKb8cQrlOobZg9vX+Fhf/nUBa46n4/LNAvx8MA1XZvc32ocxQKlUWP04hq6v3edykJlXhKGdm1Z7n8OXb3P/nr/jPObvOI8rs/vj610XsfLoNfz26sPwdlHDQamAQqFAiJczt//MjWdxt7gck/pFwl3raFWbJ605CQAYt/w4/tU+WHDb1VsFePabAxj4UBMEezjhyahgeLmoUVKuQ1GpDp7O6mqPfyH7HhxVCoT5uODqrQJ8uP4MxvSMQKdwb9n76PQMKjNfhwOXbgEAfjpwBSO6huP0jTwM//4QABi9xrZiSfssUVhajteXH8eDwe54K64V9158eekRHEvLxdfDO+KJdkFY988N/H3+Jv4+fxOvPNIcagfzcxHFZTrcKijFwIX7jG777u/LGN29Ofzdtci5W4JtZ7Kw8WTF4KKcuyXwd9dKHpMxhrdWJGNXag4GRAXho4HtcCO3CEEeWkz78zT2X6x4jeZsSUWZriLQOnr1DhK6NsP2s1nQ6Rn0jOGpDk1sel4ZY9h8KhPuTo74YN0ZpGbdxQ/7LmPlv2PRtomHzR7HWnYNkHr16mUy6pWaJbtXr144fvy4yeOOGzcO48aNk71dq9Vi4cKFZk9QSeqvP5LTsTs1Bx8PagcntcrezbkvLNl3Gb8cSsMng9vh54MVX2DeiW8NH9fqa/QYY9hxNhtRoZ7wc6vY//SNPHy75xL+SBZmSApLy1FUquOOO3b5MZy4noet43vAWW35R9eSfZfx6eZU/HdIFMYuPwYAeKipF1oFuJm8n9z1YOXRa7h8swC7U3Pw7d+X4KxW4Y+x3QBUfaZ9u+cSACA2wgePtgmQfI8WlJRj1qazOH0jH0tGdq42qMkvLkNxmQ7+blos2n0RWfkl+GZ3xeP8fT4H34/ojOe/O4RT6XmYMyQKA9oHQaGoeBJbTmfig3VnMO+5DugU5oUT1/Pw1MJ98HPT4NCkvnjzt2QkX8vF9rPZWP1aLB4K9TIKSI9euY0XFx/G2/GtMeqRZpJtPHz5NpwcVVhxtOoLbnGZHgCw/Uy25H1sZdHui5i77RxW/TsWUaGeZt9vw4kMuDs5oHtLP9l9luy7gh0p2diRko1Fey5hcMcm+GhgOxxLywUA/HTgKp5oFyTojk2+losuzYyDTcYYvt1zCS0DXNEnsuoL/Fu/JWPzafkR1UO/PYgB7YPwxV/CDM+F7Ht447fjePzBQIzsVvG6FJfpcPNeCfR6cH9fq45eR7smHpiw+iRe79MCl28WcMcwBEcGX+26gAW8x8nML8Z/erUwalNBZTfqIy19oXFQ4b9bUnGroAQfD2wn+4WGMYZxvx7HhhPCbHFhqQ5v/nYcncK8MWXAA3DV2C9MaVBF2oTw6fUMb/6WDADo08bf6Nt1TeQVlmHgV/vQu7U/pg54wGbHbegKS8u5rqMPeF1IdwpLzQqQFu2+hE82p6B7S18sGxUDAHh9+XFc4n1IG3T8cBuKy/R4uVszuGkdsOlUJhgDTl7Pw/wd59GthS/G9jb+sJbz88GrKCrTccERAGTnl0gGSDdyi3Au6y56tvKDQuLzvUynx7XbhQCApfuv4EL2PQDA3ZJy5BdX1Qs5OapQVKbDG78eh0qpwPGpj3KZpPTcIny2JRXZd0uw98JNAMCxtDuCiyWfoR2Dv9qP89n3cOT9OGgchAHX9rMVwUfS1TsAgDd+PY7tZ7LwxbCHAAD/XpYEABi19Agebu6DrWcqBrTk3C3B3ZJyXKx8HgAw+OsDmPHkgxjRNVzwGB9tOIuiMh0+XH+GC5CKy3QoLqvIWC3Zd1mye7G4TAcAuJBT9Rgl5Tqj51AT90rK8eVfF1BarsfBS7cQFeqJz7amQqVU4K24VrL3S7tVyL0v/pn2GDycHLnjGS7QC3acx2fbznH3KS3X49fD19DM14Xbll9chqz8Yu71BCq6E6UCpNM38jFrUwoAYHtiT7Twd8W124UmgyMAuHyzwCg4AoBfj1zDwUu3cfDSbYR6O6NvmwCMXHIYBy/dxgdPPcjtV1Kux4TVFVnJBX9d4L4AHJjUB6XlemTll+DZbyrmBFxzLF3wGF/+dQEPN/eBt7MazmoVl7GauOYk1v1zA6MeaYY3+rTElzsr2vfCw2F4MNg4E1RcpsO5rLtGwVGguxaZ+cW4mFOAizkFcHRQ4KOB7Uyej9rUoIq0CeE7faNqsk5nG2SPPtuailbvb0L/L/7Goj0XcflmAX6wstD2j+R0zFh3GjoThanlOj130ahPftx/BcO/P4jfj1/HvZJyPLvoABbvrTgP63kfaGczqmpIbt0rNevY/92aCgD4+/xNlOn0yC0slQyOgKqMww/7LmP+jvMwJJu/3XMJ+y/ewpwtqRY9L0PGiu/yrQLcumdcfN119l8YueQI9py/iVKd8WuYdrsQ5ZWv7ZmMqvdhXmEZ7lYGSP8dEoVHWvpyt+n0DAcquzL2XbiJf33xN9YcTxdcTItK9bLtVykUKNfpcb4yiNl4MgM+LsbZJvF7at2JG0bvw/zicmw/Kxztm19UBvEzXbT7otHx9bysv6Fw+F8L9qLr7L9w5Mpt2dorQ7vO82qP7hbbtvh8zbHrXEF7blEZsu8WY8FfFzBv+3nJ19ngJK/u5a+UivOydN9ltJu+BZtPZeJeSTnmbj8ned8tp6vO4/U7Reg3/28cvFTVLWsIVhljKOAV29/ILeL+/enmlMr2CwMSviUjO2Pus1EI93FGE08nODkKP/OOp93h/r1472Uwxrh2LNwpX0+kZ4CjSoEANy3CfFzQpZk3mlcGfemVbdz8Vnd0CfdGYakOT3+1H73+uwvdPvmLO8a6f25wj8s/l1dvFUo+5qvLkvDkl8ZdiIOjmwh+P3ndvvVIFCA1AEeu3Mb1O9JvtPvZXylVqXqVUv6tnJ5bhC2nM6sdRfPnPzdQqtPj9I187EyxvhvgbnEZ3vwtGUv2XcGeczmy+41bfhwdPtiKjLwi2X0skZVfzGUyDG4XlFpcvLlw5wXsu3AL41f8g/nbz+Hwldv4cH3FRW/v+aqLeamu6mJ+p7D6AKmkXCe4ULeevAndP9kJoCJ4eTDYvCV75AKq6hgCLr4pa0+hy8wdEntXOHTpFu5JXMSPXb0jsTeQV1SGe8VlAABXjQPUoqH+5TqGpKu3Mfz7Q7hTWGZ0/5JynezvSqUCeUVV9zkhc/Hg7wMAjFW8Pvt4gRhQcWHkyy0sM3qvlJYbnzMHXpfJ1VsFSM26iwvZ91BYqsOQRfKrERSXV3whOM97j0qdW0scvXIbp29UnAe9nmHp/ivcbbfvlQoK6sV/G3yGYwDAhhMVGZzp686AMWDGutNIycjnAvR+7YTTwfxzLZf7d15RGW4VCP8WDH8bk9acRPsZW7HxZAZSMvNxk/el4tDl22CMYfc56c+dAVHB6B3pj6c7hmDXO72xb2IfnP3wceyd0BuRgRUZ0Ot3qj5H/rmWi6z8qoCwukA0yMNJ0BUW7OnE/dtN44BW/m5YPLITwnyq6uvKdEzyM5UfIF2UOOfpuUWyn4tPdwwR/C71N1uXKECq506l52HIogN4pPJCAlRcgO93+y7cxJc7z3O/mwoCus3+C/9elmT0jVmsqLTqYpRSzUglU/hZFrnA9vSNPGw+nYniMr2gCNhajDE8+80B9Pvib9yu/IDediYLHT/cZjLTwhjDltOZWH/iBgYu3IdT6XnI5tVP3MgrFuwvFwiJLwpS/rkmvKDrWUWXFAB0CfdGmyDzAqRMUZvMVVgqfZHQ6Rkm/O8E9osCCKAiGJD6e5N7zfKLqjJI7loHo+LcMp0exyvrVaSILwj8Wha9ngnO/8FLt1AkkYE01JR4OTvCTVvRPfTVzotcYTRfVIgHWld2MeZJZJCkAqQM3vk/k5GPTSdNdwkZ6PQMtwpKBUFyTaYv2HQyA88sOoCh3xzE3eIy7EzNxqWcquB5xdFreHHxYe73t1YkCwJ8vlO8bPS+CzcFWTh3rSPOVmYJe7f2Qw9RjVJ5NV+87pWUY/uZLPx25Bp0eob//HIMAxbsRfK1qiA7r6gMl24WCNrB5+0sXeAf4uWM7rwspUFBqU4w6rGw1HSmOthTWNzdhBcgtQ/1gFKpgJvWEdFNvQT7Sb3/+KPQLuTcA2MMSVfvIL/y72irqAtxcGVQ5O2iRoSfq+C2y7cKUK6zX5BEAVI9d/SK8IP4uz2X0G76VqM32f1m1dFrgoJCc3Ikhm/cpeV6TPjfCaOh5FJ/7NbYyDuuXLbjp/1VQ56r+/Ay5fqdQizddxnXbhfh6q1ClJbrcflmxbe2yWsr6gy+2mXcTWLw86E0/HtZEsYtP47ka7l4/VfhAIgy0QUyv0g6OL9jRoB000QXR3M/FwTKjMAR479O1WUFD166xQVUBSXy53nF0Wt4XiKAcFApJS/iR65IB0i5vADJTesIR5WwgKlcz6BxlO8OFneP8YPVcj3jaoyAim/iUl2bhguUh5MjvCoLvuW6ilsGuHH1NnlFZYLuM6CiXkX4uw6Z+bwA6UY+tp0RfvFwUavg6ypdaJ4rCrAt6WJLu1WIuVtTkZ1fjHKdHhNWnwBQEYAsP5SGd/5X8Tv/4s6XkVeMFxYbv8aMMZzhZZCKynT4/XhVV5eHkyPXjfpAsDueiQ7B2N4RgroesYEdgjHh8ciK9hWXCz4TgIrsy+ZTws/wVUevo7RcD3etcWmwqcJ9X1Htn1dlMLX8UJrRvvx6Kb5g0Tnzd6865uNtg7h/RwYJ6/V+PHAFF3PuCbKKybyM2h/JNzD8+0MY/PV+vLT4MN787Th+OnBVcIwXY8Ow4tWHKwc4CJWW663OGNsCBUj1HD8I0OsZPq6cB+P7v203CV1DZNQ9IXOdzOd9+w+q/Jb06+E0rDh6Da/9ckywb1ENAhU+/qgQwzda/iRvhaXlgm93pmojTLl5rwSPfLIT09edwezNVfOjZOaV4MiV24IUu5xVR4VL5lwWfRiVir69ibtvDMzJIEl1pwR5aKFUAPEPBiLAw7wAiU98Aef7ds9FPPftQbzzv38AAAUyGSQxfpDioFJItvuKTG1FXlEZF1C5ah3gaNTFpkehiaxJsaiLLVv0Gs6uLOo1kDrvwgDJ9NQCLf1d4c4LkMSJWP7rX67T40ZusWCfk+l5OJspzHo4qJRGF22D2wXiAEn6/XQp555Rl9hXuy7gi78u4JFPduJEep6gGH7WphTcLihFqwBXTPlXG+kny3vMcp0eFyuzGzfvleLmvVIoFECfSH8AwNe8LxU3C0pwprLerk2QOxxUSrwTH4mnOgjrZcb2jsCMJx/EuN4t8PnQDniyQ8Wgkbsl5ZKvU77ofWWo9+rQ1AtvPyYsKPeWqDUzEJ/rF2PDAUh/OXu4ufTUDeKgMpD3tzgkuqrbKzJQmOX9dHMq+n62G1pe0J+eKywZMEwhkHwtF38k3+A+Y0bEhuHNvi0RFeKBmOY+CPWu6L4L9Ra25YxMVq0u0Ci2eo7/AXWwcj4RAGgZ4Cq1+33DqM5CJkJK413IDPUg/G/ABmU6fbWpcnPo9AxZvONfvlmAnLsliJ+3Bx2bemLh8I7YejoLBbxgjP/hmZVfDIUCWHH4Gp7pFIIgD+lvwwDwE6/eYiuvUHTbmUysTZaeVFBMXCPjqFIIgnJ+F8uziw7IBgbmZJDuSgQGf4zrBr2+4gNZrqDTlOIynWDofPbdYtwpKEOwpxYzN1YEE3+fv4nElcnIlaj5EWOMCS7MSoVCst1y7hSWcgGSm0wXm+G1f/HhMMHkiQBQWKLDqKVHoFQq8PGgtsipJniWysoZsh3uTo7VzlnTLsSDqwnKLSqVHFRQUq5DQYkOAxbsxQ1Rvdy+CzeNgipHlUL2ccWvseFclev0uHanCOE+zijTMfT5bDcA4PB7fTF93Wk8GRWMQ5XdmqU6PWb8eRpARRDI/yx4pIUfAk38zQDAuax7WHPsOn45lIa5z0Zxmcum3s7oHemPv1KykXa7qp05+SW4WZnJa+lflUFx11bUmBk+o5t6Owvm1TKMfist13OZwDnPtMeJ63mC1/3RBwIEWbiYZt4Y27sF/Nw03GgzTxOBri9v8IG71gFv9GkBR6UCX+++aJSd/lf7YPx62HgdUXGANLhjCFIy7qJ/+yBB8CPXDS7+8tGxqScCPbQ4n3UP2XdLjD6v1Sol3u//gOT8UD8mdMGKo9fwcHMfNPF04grG7YECpHqOf4HamVqVXq/rWfv3nr+JLacz8V6/NnU239Dd4jLcKShDU15hoIG4q0euBOnKLeM5PqT2levmcrNwDo6b90oEAcb1O4XYfS4HtwtKsf1sNib/forrInJRq1BQquO6SU5czxWM7Fh34ga2ju/J/c4Yw3+3psJZ7YDVSdcF3xD5wd160dBZU/iFnYDxPChlvAD9sEy3EmBeBqlAItDwc9Vwc/RYMxKxqEwHflWEIYh7v58wi2BqdBDfnC2pgi7JkjK9RYXE/JFJblrjIu2iMh13Hpw1KmgclIIs2OErt7n6pmu3CxEb4WPy8W4VVFx4Ex9thfyiMny/9zKu3Ky4uHs4ORplsAwUCuC1nhGIbe6DHZXddhm5xZJfErLzS7Bk3xVBZsDXVVMxv47E35KDUik5NQIAXBFlNQwB0kcbzmLp/iv4YthDeIg3d9GkNSexIyUbG09mIoiX1finsrv8qQ7B+PngVa4dod5O8HQynTU7l3UXv1R2P83ddg6vVE5V0NLfTfDYBvwAmV+ro1Ao4OOq5mqyxNkV/vw91ysDruZ+Lmgd6CYIkEZ3b46+kf5QKhRQKMBNV8LvVjOdQaq6rXtLPziolHi9b0s816Up/khOx0cbKrLLDkoFOsjMCxUuCkK0jip8OLCt0X5+bhq82qM5N7+XgfgztXtLP4x/tCILptczRE7dLLiWBXpoZSfPbO7niklPmM4C1hXqYqvn+Bkk/uiAXw+nodvsvwTZClsqKdcJCp9fWHwIyw5etXrYuyWu3S7E4r2XMWrpUfSYsxNHrtzGzwevcsNvgaoMkmGoq1yAxP/GWqbTY+bGs5JDl+WG2+ssHAFmuIgEe2gR5KGFngFvr/qHu31V0nUugOnTpmK+G0O3g/ib3bksYRfD/ou3sHDnRczZkmqyX97cTFh+cZlkNo2vurosQ42NOaPYpGp5FLwrabcWvuhiYvbm6trHGOMyXJZOAWAgrtcqLtfhbol05smFF9AZAqH0yoBTrVJC46AyClBmbkzhpkxwVTtg1ZhYDIgKxqCHKrpr+MXfKZl3sWTfFZPtNQTXIV5O8K68UBo+MzycHGUzD8lTHsO7j0dCoVBwNUhXb0tn8Hady8HaZGGA2bGpp2ybHB0UUEA6QhK/bw01SIbRZ7M3nhV8pvG/FEq9Vzs29RLMXB7i5Sz5nJOnPorR3SsCIf7INnetI85VZtBaBbiiZYCroJ6Gz03jADfRbOj8j4fWgcL6HJVSwb1HDEGWp7MarQLcBMFBkIcWz3Vpimc7h2JIp1DuC6gXL0DyMlGD1MzXBT4uajT3dcFHvKDGz03Dva+Aimyhi8YBI0XzWhmOYa73+rVBS3/pHgwXtQpqlRL92lXVLSmVCqO6KnsWXluCAqR6jh91n04X9sWm5xYJ+sqtkVdYhn0XbgqKXdNuFaL15M1cESSfuQt21sTj8/bgw/VnuIzFS4sPY/LaU3h56VEAFRdCQ4Bk+DCUCwn431jTbhcaffMxkMsgWdrtZsggNPFywpfPdzTZxWGYPM7QTVJdBsWcLI0lTA17NpCrOTIwdDncNmMepOoKctUOSqwcE8sNWzYHv26MX5cmrp3iHkMmo2Lq+HIZJP68Sm0qi1evVQZIhtFjppaYcNY4oH2IJxYMewgtRBccraPwfnIFwYb3rZOjCt6ii6iHk6PRNu42XhBhCJDSbkkH3VPWnjKqHWrh7yrIrjb1rgpSHJVKxEhMjAgIp+YAKt4TebzXTe2gFARC/D8/xiqeZwCvgLhzM2/BxT3U20kQxLQKcMXf7/aGp7MaLStH6/G/aHo4OXLzMrUOdIPGQQV/3uvKr+EK8jSukcu+W9VWrUTxvasoMPByVkPrqOJGbgHGNURSj+1lIoPkrHbA3gl9sPHN7kb78QOrByq7x97v3wbTRJPf+kvMEWaK1GdVkIcWSVMexeH3+xoFi+LMdEOZfJcCpHqO38UhVQshl8o2mLnxLHrN2YnXfk7C26v+4da+Mcy9M+y7gxj+/SGMWHIYn25OAWMM3++tCCJWHr1udLzanPadMYZT6XmC+hxAmCUoKdehoFTHBS6GD3e5Yf65vAu8qekR5Aq0LV2BPCO34gMzyMMJ0WFegg/v52Oq6hMclApEhVTMMHu7oBQnrudKzofEf16q6l5sCxkKgDs29UTKh49L7pMnUbfD/4ZuKKjMvltS7fQThq6lnq38oFYp8fEg4xQ+AJOjvMT4mT9zsqnOGsu68YrLdLJD0W8VlGLW0+3wdMcmGP5wGICqaR0MAZJcFxcgzEBpRIHUNy92Evz+QkwY1kqM8jFwUquMLo4eTo7wNHFhNTC8nnL1ZUBFjUowr4vL302DJl4Vr32YjzNCvKpqWBxUCox/tBVe6xUhOIZUN9GmUxmI+mAr97ujSmlyGodQbyd8PLAdhkSHYPVrXdHE00kQYIR6OQu+lAR5OHHFv4Y2JvHmsNLpGZdRMgT7DrzXjD/sXKoesLqPB/7npUJR9Xk18YlItApwRc9WfrIlC/zgqrpieye1SjJAUyoV3EzZT0ZVdN05qpRI6CZcIkZh4WeL1GN5ODlC66iSHHHn7lT1XLaN7yEYGVefUYBUz5VVk4oUv1FLy/X4KyWLu1h9u+cSrtwqxKZTmfhf0nV89/cljPk5Cf/6Yi+AqoLOv8/fxFe7LmLfhVsQ4wcJbhJDUG3l54NX8a8Fe03uk1tYxmU11Col9+Ei9znFLzqVyhIZApCiMpk5cqztYqssemzNW8aiT2t/7t/lesZlILLvluDJL/dxi07y8QuLq1sj0qOa2gsxw7xALhoHaB1VkvVW4pE2gDBQC/dxQXM/F5TrGb7/+7LRRId8hkCjf7sgnJoRj+ExYZL7OTma/7HEnzfInADJRe2AvRN6S9ZXSB9fZ5T5Mkxo+UTbQAzr0hRzn+3AzWhtaI+rGRkkF975Fv8ddwrzwvDKgLpHKz8olQrZ4etAZQZJIkCSurCKswXuZrxvnuscila8rIC/u5YLPGKaeQuCCgelEi4aB26YO1CRcegUVlUtZgi2xEXbN++VmA6QvJwR90AA5gyJQnTl8fhTKbiI3sP8wFNqGoljaXeQX1wOjYOSG/jyEK/7kJ8ZE88VBACfVi7SPG9oB8n2uvKyWe7aqqJ5DydHbHmrB358uYvk/YCKgOzFh8Mwunszq9YeNNg6vgd+HhWDmOam69ksIZVBMlVIPueZKLhpHfDp4PZcJq8hoACpnistF16gxR+4Ggcltw4SAMzfcQ4vLz2KV39KksyKrE6qqCWQ6665U1hqVM9zjzdCQdwHb0vf/i3d/cV3u6CUy2q4OznKVDpU4QdIUl08hq4YuSUeGLMsi8R1sVV+mPJHG4Z6C4vNTRVeGkz+4xT6/HcXbt4rqXYV+0daGE8YZyDV52/I1LlUfvj6mplm52f0tI4qrqh0/o7zmLj6JHT6ipFg4qyeoavKVWJ0Fx9/CYXnOoea3RZzAiRHlQIhXs6If0B6vTOxvKIyQRF1//ZBWDYqBpOeiMTUAVXdXuLg1E1T8btaJf+aufCyWfwASaVUwFmtwrQBD2LmoHb4uDKYk1pWxMBJrTKqU5HqYnsmOoRbA0+u7XwznnwQ/dsFIeGRZoLAyt9NgyejguHvpsGwLk3hyHtviud+Air+jpr5VWVT+XVDfHcKy7CONwWGWJiPca1MfNuKma2luqr4AU6gxDQShkx0uyYeXLbvgyfb4umOTbD6tVj0iqz6UiOVQXq2cyhOzYjHwIeaGN0GCAd5iINVc7I2Hw5si/f716w7qoW/m2DJGwNDN6jURJPVkQrY5OrOAODh5j44Me0xPFvN33N9QwFSPSeupRAXu60+dh2dPtqOfy3YC8YYNzrjwKVbkrM4V7eshVSXAL+bxcHEB35NmTNR4J3CUi6D5OHkwH3IyCV6hAGScReQocZLbpZlwLIskmEYtCGDxJ+ArYmXE+Y/1wFAxTdOjYN01oZvw4kMXLpZgC//uoByiTXB+NqFeMim4gsliq0LeaOpAMhO7idWXKbDc51D4eXsiOEPNxUUgl65VYBpf55C3Nzd+EFUYGzoIhZ/yxfjBwtvxbXCyemPye4rDJAqugyf6xyKJSM74/uXOhntb3i9fVw1glFRcnamVi2JcHzKo1jw3EPwdlHj3z0jBN0n4oV6m1cGA6a62PgXGX7Nkaum4n2tdlDi+ZimXGDND5Aj/ISBglQGiV93Y/DfIVFG9SEt/V3h66rBQ009sW9iHyx8viOc1Sp891InjOgajoXDO8JV4yCoufJz02BAVDAOvx+Hh5p6CT4XHCSes54xwXBtfpecmKn5uzqHexlt693aH0sTOmPd61VdkF8N74hHHwjA631bctuc1Q6yGXD+6C4PZ0fMfbYDosO80at11azZcvWEpsoO+I9narJHe/hi2EN49/HWmP/cQxbfV6qLrbprg6XdePUBBUj1XInowibO4Fy7XYR7JeW4kH0PBaXCta7EQ7gB6S4TIWY0pxB/ThBTi6/m3C3BltOZFq/9ZVDd/CUAcKegDHlFFdkvD0EGSfox+e2VKjg2XDBNjdYy9ZyBim7Q349fR2ZesaAGCYBg2LCrxgFPdWiC0zPi8VTlJHJtmxivdC2lqFQn231l6MZ7uLkPAmSCzGKJbKI4g8TPcJnqStUzYPbg9jjyfhz83bRo5uvCdTXoGfDzwYog/ZPNVZMa3rxXgvTKgL26Ojb+hchZoxK858VF1vznZcgg+btr0TvSX/JbsyEbpFIqsPPtXkj58HGsePVhQVeolA6hnvByUctm8cK8haOnokI8K9prIlPGPw9a3or2/HoNsT3v9MayUV3QNUL43JzUKqNMUJsgt4q5dCq7uh6TyZq5aR2xf2IfrB5TUdPTv30QTk6Px6Oi/fkBnXjhX35QJJdBCudlf5qIAqT2IfJ/B/zXpotM8Xev1v6CDE+/dkH47qVORudE7ktYB5lRee5aRwx6qAkcVQrByCxz8V9jczLGdSnAXYv/9GphVbv4XWz/6RWBbi188FZcSxP3aJhoHqR6TnzhlpqG3uBecbmgO+haNQvcSgUy4sf75dBVvP/7Ke53U8HCG78ex4FLtzC5fxu80r25yceWUt38JUBFBsnwAezprOayQuZkkKSCQ8MF09BF6aBUGI1cEy+/IPbj/iv4aMNZ+LpquK5LQ71IywA3LE3oLLig8DMoXSN8cOCScd2XWJleL7kuFgDMe64DPJwcEezphEAPLbeOXKi3E67drgiSpeqvxBmk9/u1gVqlxLmsuwjydMIGmfmUDOeff1E0PD+dvqqNhvq5u8VleOzzPdz5r66OjX+2nSu/qX42JAp/pWSjTZAb/ru1alV1qQySYZST1Ig1fneZ4VtwTHMfBHhokcpbZZ5PoQB+/09Xk21WKhXoFObFLQXSrvKCbzqDJN3FZuiek9LUxxlNfZyxV7RunJOjyijDYchYvNYrAg839xYEKGLiQK66CSbFXSzCLjbj58zABF1s4lF7nwxuj3+u5eL7vZdxIfse3LQOmPNMezTxdMb8Hee410acqbOUn5tGsFiuganpJT4Z3B4znnoQ7laUF7gKMki1V55Q1/jv3ZjmPniXV2/WmFCAVM+JL2ymCirvlZQJLu5SGSRTxzZs48cD/OAIMB0sGC70szelWBUgVVeQDlTM2Kyp7I7wcHLk6lpki7SZ6S62DScysOCv8+hYWfDp66oxmm+luqH+myrXVDIM13dRqwRZgF684myx2AgfYJvJw1e0Qcdkl9Vw0zpwXXn8b8jzn3sIr/6UhJv3SiRfa0MGydmxoq0+rhrMrswEzdx41mh/oOLC+cPIzkbbDZkV/ktoOPVHr9wRDBOvLoPED9wNQdjg6BAMjg7BH6L5ePij2AyzTvtVXkSVSoVRwCuXhSsy0cUa5K41q3uAn8EwzBNjfpF21X7mDIQwvGYG4pFQ4u7Sh5oad01ZSm6SQQCiIm3jc6VnVa8LUDGRoEJR9R4JcK+YC+i5Lk1RWFqOMh3jsj9vx7fGsbRcJD7ayui4lpLLFPub6N5XOyhNvo6m8N/r5q412BDwA3pXC0eGNiQUINVz4tmHTX2LiZu7R/D7NZmJ3wzyJQIGcWE3/0MMqL67CagIKErL9RZ/qMhlSPhuF5ZyXULuWgekV34Wm5NBEq+UDoBb225XZa2Jj6vaKECqrkhbfD0I9nQyu789KtQTzXxdjNZAE7tbXCY7BxX/2zy/ENVd68h905O6MBRxo9iMP+DEw84NTkx7TLKGyDCyTepcGRYJNqiuBslUwk7ctcN/XoW8NdAM1A5KlPPe0+L5WKSOI2ZqDhq+UY80w/+SrqNPG38uYDA175LcKDZzBkKIXzN+Fx0gvyRETXRr4YsFwx4yqmEChN1qUjVIjDEoFAoceT8OxWU6eLuo4eWs5gJnfu2cODsVGeiOY1MetclzkJq2wtTowJriv98MU0E0BvwMUnV/zw0Z1SDVc+IPbkuG2Vc3saDUBbewVCfIxgSJvvWYCpDCeEuCnEzPNauNfCVmZJByC6uyZA4qJVeDJLcWmzkBHZ/USJjqjiEOhoIs+MB1VCmx7vVHqp0kcmdqDr7ceUHyNv6oL/63VHcnB+42qRGNXAZJYkSKXIAk105l5e5SBe3Hr90R/F59Bkn+NvEQdf7fh+Hf/PMhDtLFEzAa8INzQz2Vgbk1GuG+Ljj4Xl98/mwHbpupLjZ+O/ntMtWNbiAu8DZk8D586kGE+TgLZlS2pQFRwWglUa/loDRdg2T4E/Jz03C1bvygqK4KeN+rXILm1R7NuXnJZg9uV2uPN+ihJmji6YSZg9rVaiBW1wQBUg2mIKjvGu8zayQs6WITq67LSrxSOFBxkeFfoHzdNLjBm5fEVBcb/yIsN2zelBKJDI/Y7YJS+FfWmCgVVRNlmpNBModkgFRNDZJ4+oAmEvOlmOKqcYC3ixqFpaa7ROXwg5kAUQbJSZRBSrtViFsFJXioqRdvHiSpDJJ0ICR3ITNcIMUZJJ2e4XharmBbdfUtcsEuUFHo262FDzdf17GrdzDih8MY/2grrruNHzyIMzhS3YMA8OFTbfHC4kN4+7HWeLZzKDo380bv/+4CYNnoI3FRsKksKv88aARF2pZlkPiB1oux4dxq7nVJMIpNafycpUathXg542KO6cyprcU9EID9E/sg0F0LPWP4T68I2SkHbKF1oBv2TexTa8e3F37gX5uTB9tb431mjYT4m78l0Xp1AVLWXeN5Y8SPJw5aTNXj8O9r6QSLgPzyEHy5vHmaFIqqNZ/MmSjSHL5uxhfD6o6RKZo6QWqulurIZWzMoRTMHKzljqd1VHEXT0MwNOrHIziffQ8vPNyUCzIkM0gWTNYIAIbPS/H7I/labrXLlYiZeus4qJT45ZWHsXDnBczZkoojVyqyU0qFcNkNA36AsuLVh2Uny4tp7oOT0+O5ri7+MbxrUFwrlU2RonG07ILDf82cLJh5vLY4CkaxVf179Wux+GzrOcmlJaYNeADPfnMAo62oV6wJQ72eEopaDY4aM/6faGPuYmu8z6wRYIyhQFQ8akldT1m56Qu7dBdbueCbrXiZBbl6HMaYYK4dS5foAIDSygJa8QrnfOey7uHByqHxCvAzSDJdbBYGaj4uakwf8ADK9QxztqSipFzPBUgVr4eOu4D9fPAqtI4qwRpgQMVSGpYSZ2zCfJyNZhk2Ryt/NwyICubmnOFqkCqDB8MIHsNQfEC45EVVeywLkJQKQ5G28HzvOFuxwHD/9kHoEOIpmDhTjjkBgngeFoaqLJlWXdV2/t9LdX87/GM6WVgTJEf8+PEPBmLdP8YTIWplutvk8Ls4nOvBBcpBZqLI6DBvLB/9sOR9mvu54sj7cQ1yfpz7Hf/v3NoC9obA/n9ZRFZJud7o27S530iBqgxS30h/7BAtEglULHEhVliqE9Q5iQMkuSRPmY4J/miqGxrPl5VfjIU7L+DgpYrFaU0FSEVlOmw6WTH8XKFQVLsWnaWBmpOjiuuimLvtXOUxKm6bse4Mlu6/gjX/6YogDy0mrz0leQxLFls14GcQ/jskCpl5RYLh7OZSKhVYMKxq4jd+F5vcuZBaC8rSDz1DUC1+3Q2Lkz7aJkB2tmGxdx5vjbOZd/GiiaJWcdaEsarMkyCDpDI/QOLjvx5ya2WZg//4z3YKwYdPtUW3CB9Eioqo+UXWpuqWDPgBUrcI2y0hYS3BKDYLPqMoOGqYrJ3rrqFpvKFfIyA1NNucD08DwzfqcX1aYNITxvNUSNYgiYb5GwIkwyRzchkZcdfcxZx7uJAtPa8MX3GZDjEzd+CnA1e5bdUtVmrI2CgUVdPby/29VjdEX8yJ13VhuOiXV0ZIS/dfAQB8vu2cbL3UM9EhVn3oa0SZBpVEHYc1qrrYdCiWGeIulSKXqkHiL7Yrxs8g8bMJF3MqMladJGZAlhPk4YRNb3Y3+XjiizB/GgF+gMQ/r3J1VVL495OaNdhc4q4nhUKB57o0NRoyz//iY16AVPWavRhr/9FR/HmQpGqQSOPSvnIi1MaOMkj12D2JiQ0tCZDyK2s/HFVKyTR8tkQNUkZeseAbsyErZCg+lctCFIoWe525MQUzN6bg1Ix4k10mhgson7ndO4IibRuNYuMvPyGXFZEaSdgpzAvv9W+DdmbOjC3Gv3irVUpY8DKbxO9iKyipCpCiQj3xz7VcwT7C9lQ1QKkAkqc9ZnJZFEPAomcMjiolyvUVj1WmY3BUKSTXsaqJQlFm81blHEhqlVKQzVALAiTzTyo/yK1JjY+5XXz8x3M0o50t/V0xsEMwQr2d0cLf/ot/VjeTNmlcokI9sWxUF4Q28houCpDqsTuFxsP0LfnwMQzjVjsoJetMDBmkTmFeuFdSjpTMuziTkY8zGfmC/RSKqrll5DIyUtmuiscohquffN2J1Ppi5l7I+Isj1mQU27AuTZF2uwBDOzdFN96CryouKyLc31XjYFRQ7uOqRscaTManEV3IbZZBqsw0FJbquCyfs1qFAP7M3pLD/IX1ONXNImw4V+X6ioCIX5cd7OlU7cg1Sw2ICsbGk5nwcHbEtjNZ3JQW4vodS2qQ5Eit4m4u/hcajZlRr9aMdiqVCsyzYg2t2mJpBow0fN1bWl5r2dBQgFSP5UqM/rHmQ95RpZQcqWSYELFfuyC0CnDDC4sPSd7fVe3AfejpGeMmfeOTmmcHgGwtkYFUwGVuV4hCgeoXqzWjrzz+wQDJ2a5VyqpuIz5XjaPRpJY1XWdJIxp5JTUbsTUM2a67xWVcwb+zaN0uZ6lh/rxAw9Rq7wZK3rkSt5y/orqt+LhqsHJMLI5cuY1tZ7K495n4fa7kvU8tLTz/fGgUUjLvWlV0b8D/e62u63Vop1AcunzLqjW/7I3/fpWaKJKQhogCpHosVzKDZE2ApBDMm+LjohZMItmtha9RMTafq9aBu9B8u+cSdqVmY/3r3QUf/nIzEVcXIElleMwdYl4xzL9CTYb5y3UB8gMkfkDkqnUwmkLBq4YrdRvXINkmQDLMqZNXVMZl+ZzVDoKgR2q2Z357IvyrH3nGn0lbHJTW5lBqcfeXqYJqS79cDHooxKo2CR7Tgr/XT55pL/nloyEQdLHZOFtIiL1QqF+P5UpMi29NgKQWZZD4q7YHeWjRKsDV5EzOrhoHQU3Muax7OHr1tmAfuS62EhNLOABAucSwOPO72FDtKDZzAiS5eTy4wmPGBHP5OKtVRktW1DiDxA+QVLbLIBkCofziMm4uJGe1SjAZodQFmZ/FizDRRWrABZOMGZ2bUO/am0FY/L41VVBtSbBiK5bW4zTE4AiofqkRQhoieifXY3I1SNvG97DoOOKgih8g9WjpB4VCYTJActE4cBkCgwmrT2DR7ovc73KLfdZmFxu/+0Ru2Kk5w/zNySDlFVW9FowZT8JZ8wwSb+SVo3kZpMhAN3z/UieT+xiWrcgvKudlkFRoVc18RPyATbzyuhRDe8XTPQCo1UJOcZeaqfexPS7c/MdsoLGPWapbaoSQhoi62OoxqQySWqVEywA3vBXXEvO2nzfrOI4OSkGGw4f3745hngBMd024aR0EszUDwLXbRZi9KQUDooJRVq7HG78lS97X1CKgQNUQej6zM0gKVNvFZs4wf7kMkgNvFBs/g6TT642KtGtegyTKIJlxkdn8VvWBsrCLzbC0iAPiHwzE2N4RsqPu+N1RFmWQJM5353Dvau9vLfH7tj7MKn0/Ei41QgESaRwoQKrHpJZoMAwB5md0mno7Y/GITth0KpOb3JDPQalAM18XzH02Cv5uWuy7eJO7rV0TTwCmLyyuEhkkg9VJ17H7XI5R0bKBXPG2geQoNjMvchVdbNw4f0nmFGlLrUUGVBUel+sYinjTGOj0QJno+XrWYDkKwLJ5kEK8nPBOfGuzjivsYqtaikOhUOCdeOO5sQz4WccI/+qXTlHKvD9aBbgi0MP6UWDVqa6L7T6Zz87u+N2X5kxTQEhDQAFSPSbdxVYZIPG+samUCrQMcEOEnyseDHbHp5tTkZp11+g+T3esKDr9/Xg6d5th6QepUW4GLhoHwePxbTuThfRc+UVWq88gWT/MX6nkF2lbPw+SXJceV3jMmCCbp2PM5hkk8XB0U9/Cv3kxGg8GmzffkmF4/r2Scm5eLXPWTvJ1VaNfu0A4qx3gJ7GAr5hUl+DTHZtwq6fXFkeVEo4qBVf3ZKqLjdQeYZE2BUikcaB3cj1muCjza2QMF05+RsdwcVIqFejbJgBNeCtnq5QKo4sXf3QcF3ApFbJZCY2DUjaDVFBajnAf+RoTqeJtftAiFSBZUohetRab9O2WThTJpxTUIAm72IxqkGoYIPEDIo1KZbIGyZIZod2dKt47jAFZlfNembN0hkKhwFfDo/HfIVFmFQ6L2+uoUmDusx3ga0ZwVVNOMmuokboj6GKjGiTSSFCAVI8ZAhk/3qR+hkwD/4IkzjbwJ8uTKph8M64lPJ0dMePJBwXbx/ZuIXlBc1TJFw0zBoT7ynfBiIu3v9l9EVEztuJUeh4A6VFs5pYwVFy3K+dBkrhdrkB7e2IPxMqs6s7nwAuQ+BmkjLxiHE/LFexrapZpS1WXQbJkPh+Ng4p7P2TmV2T6pCYNrSnx+6MuR4wJVrYXPTe5zKI9KIxmiGo8+FkjGsVGGgu7v5MXLlyI8PBwaLVaxMTE4PDhw7L7lpWV4YMPPkBERAS0Wi2ioqKwefNmwT7h4eGVi5gKf8aOHcvt06tXL6Pbx4wZU2vP0VqGiSJ9XauyE/yMj4G4/oNfhyGVjWkf4onjUx7FiK7hRrepJQIqB6VCtsZEz5jJbg1xBmnWphTcKynH7E0pAKQzSOaO9lHyFquVyiBJHdvHRY0W/m5cZsXk8WUySGuOpQvWjqtoc80ufvyLZ3XzIFk64aGhmy0zr2JiUFPdqdYSZxjrsg6F//6rycKyta26kYMNGT9rRPMgkcbCrjVIK1asQGJiIhYtWoSYmBjMmzcP8fHxSE1Nhb+/8czGkydPxs8//4zvvvsOkZGR2LJlCwYNGoT9+/fjoYcqpt0/cuQIdLqqi/KpU6fw6KOPYsiQIYJjjR49Gh988AH3u7Nz/VpTRs+7KPOzOoaMkCCDpJIPkOS+yctd0KW+/TmauGDr9MxoKQ4+ufmRDA8vVaRtLgVgsgZJvIYaUHUuzXlcw2nVMYYCExNp/vbqw9Ueqzr8l0OlVJhc8NOSLjagYiRb9t0SXoBk+yBC3Ny6zCDxg6L62MW2dmw3/HMtF4+3DbR3U2oNzYNEGiO7vpPnzp2L0aNHIyEhAQ888AAWLVoEZ2dn/PDDD5L7L1u2DO+99x769euH5s2b47XXXkO/fv3w2Wefcfv4+fkhMDCQ+1m/fj0iIiLQs2dPwbGcnZ0F+7m7u9fqc7VUUZmOy4p48ubYUUtkkMTBi9bBdAbJFKkuOUelwmiYvwFjwq6sQHfhiCX+KDb+foYLmU5imL+5XRH8DFJJmZ4bxm4glUHydas4l4blHEzVTxmCFL2eyU4X8HTHJnjYjO46S5mqczV3pnEDw0i2jMqlZaQWLq4pcUBXl+txOZsIkOrDKLYOoZ4Y0TW8wU4CaQ6aB4k0RnYLkEpLS5GUlIS4uLiqxiiViIuLw4EDByTvU1JSAq1WeAF2cnLC3r17ZR/j559/xssvv2z04fTLL7/A19cXbdu2xaRJk1BYWGiyvSUlJcjPzxf81CbDulkKhfACwHWx8Yu0Rc+NP2zd0cGyDyupC5uDiZmd9axqaYk3+7ZE95a+gtsLeaPY+MubGIbyi2ddBszvYquYB6li5w/Wn8EDU7egmPd4UgXahgzSoIeaYPkrMVg7tpvs8Q2f+eV6ZlSUbWCrTIn4/Wkqg2Rp8GGYLNIQLDjXQpZF/PawtBuwJpx4XYZaUXbM2gVqiWUcaLFa0gjZrYvt5s2b0Ol0CAgIEGwPCAhASkqK5H3i4+Mxd+5c9OjRAxEREdixYwfWrFkj6FLjW7t2LXJzczFy5EjB9ueffx5hYWEIDg7GiRMnMGHCBKSmpmLNmjWy7Z01axZmzJhh2ZOsgSLenDV8jhJF2uIMEr/GxPIMkkQXm0p+FJueMa4ry1mtMqpV4meQDF08ALguK6kgxpKQTtys63eKuJmfTQVISqUCXVv4Gt3OZzivesZku+RsdTEQP2epLs3IQDe8/Egzi9dpcxctNis371NNKBQKKBWA4ZTX5UWSfzZaiWb9njbgQZzPOoRXezSvs/bcj/ivN00USRqLBjUP0vz58zF69GhERkZCoVAgIiICCQkJsl1yixcvxhNPPIHg4GDB9ldffZX7d7t27RAUFIS+ffvi4sWLiIiIkDzWpEmTkJiYyP2en5+P0NBQGzwraQUlVQuL8rsJzKlB4l8ALc1wSA3RdVTJd7Hp9FVdZyqJrjj+BIsZeVXzJRlG6JVJdLGZi9/FJt0246Am2NP8dcG4tdhMdLHZKhBo7iccCSi+yAS4V6xebyi4tkSAqNuzNoq0gYrXX18ZSNZl5mbfhaqJT7s0E87a3czXBfsm9qmzttyvHASfR5RBIo2D3d7Jvr6+UKlUyMrKEmzPyspCYKB0MaOfnx/Wrl2LgoICXL16FSkpKXB1dUXz5sbfDq9evYrt27fjlVdeqbYtMTExAIALFy7I7qPRaODu7i74qQ13i8uQlV+MWwUVc9Y4q1WCAmTDcFphBkn4Mto6g+SgVEDuMIwxGJIrSoXxfoWlOjDGcCztDi7mFHDbDQXoOskuNvO+gfK72Hgt4v5lyGyplAr8u2dztG3ijuc6mx/UGj70fz54FdfvSHfBWtqFKadnKz9MH/AAVlQWfPNf3xAvJ+yf2Neq4AgAgkUzWQfV0szW/OxhXQZIb/ZtCQB45ZFmjbrOpz7jf25QDRJpLOyWQVKr1YiOjsaOHTswcOBAAIBer8eOHTswbtw4k/fVarVo0qQJysrKsHr1ajz77LNG+yxZsgT+/v7o379/tW1JTk4GAAQFBVn8PGxtzM9J2HfhFgZXznrtrFYJMkiGDI0gQBJ9HrkIapYs+7CSyjg5qJQmh/kLMkgSXWx//nMDb4rWajMESGU1mciRvxhbJf65Kue1a9ITls/obDjHx0RzHvFpbFiDNLJbM+538dpWlnar8YmzZiG1tHisg1KBksp/1+VFcnSP5ujawgcdm3rV2WMSIeH7lTJIpHGwaxdbYmIiRowYgU6dOqFLly6YN28eCgoKkJCQAAB46aWX0KRJE8yaNQsAcOjQIaSnp6NDhw5IT0/H9OnTodfr8e677wqOq9frsWTJEowYMQIODsKnePHiRSxfvhz9+vWDj48PTpw4gfHjx6NHjx5o37593TxxEwxDuA1dUHJDsoUzaQs/kJwkirrNJdXFpjYxUaSeVXVlKSUCpMJSHdYcSze63817pXjph8NoLZobxpLMg0R8JBjszwVuVmYV5IJCvtqqtXEwUWNmKX6A5OemqbW5gvjdq2oLpyKoCa2jCtFhtbcgLqkejWIjjZFdA6ShQ4ciJycHU6dORWZmJjp06IDNmzdzhdtpaWlQ8v7wiouLMXnyZFy6dAmurq7o168fli1bBk9PT8Fxt2/fjrS0NLz88stGj6lWq7F9+3YuGAsNDcXgwYMxefLkWn2u5jLMeny7MkBy0TiASYxV5l+MxPUq/LW2LO3qkB7FppAfxaavGsWmUhhnOgpLdWjm64Ld53KM7rvnXA6yKgu3R3YNRwt/V/Ro6Ycl+y+b1VYFjLvj5DJI1jBnyYTamhCRH/TW9Bt5E16AFOBee0t/8M+z1ISjpPHiB0Vy9YqENDR2L9IeN26cbJfarl27BL/37NkTZ86cqfaYjz32mGRQAQChoaHYvXu3xe2sK4YM0p3KIfFOjirJxRJMZRikpgUwl9S3P/O72IyHexeVlsPLWX6dsnuVo9m0jiq88HAYAPPnQZKqN+HXa+lqGCA1lgySp3NV7VJtji5T2akGidgfFWaTxoje1fWMYf6YO5Vrf4lrkAyUJi6gLoIi7ZrPg+RoogZGz6qKoZUK41FsBaU6FJVJT8MAVI1s47fTsnmQ5NU0QDLnfrWVKTE1jYOl+IFkbQ7B5r/2NBfO/YWG9pPGiD7F6hnDMiGGImZnjYPkMhoOJrrYnHnD/C39ZifVneOoUsoP8xePYpOIbrLzi422GRhqtK0JAhQwb5i/1QFSI8kgAYBXZRapb5uAava0noOgi40+Wu4n/L8Dl1qaRoKQukbv5HpGPAOxs6NKMgPDv3iLgxf+B5TcivZy1BLD1h1U8ovVMtEoNqmLeSYvQPp5VAx2pmZj8V5hnRH/A9bccEApVaTNe7p6VrMibXMCk9oKkGyZQQIq1gPbc/4mhnaqvbm7+O+RulysltifSqnAp4Pbo6C0HIG1NI0EIXWNAqR6xihA0jgIluswMFWkzZ99W26JDDlyGSS5S7R4FJtUXZAhQPq/R1vhkZa+eKSlL8J9nDHlj9PcPvwgQC6eUSkVgskfFYraLdI2q4utlgIB/utgi86LMB8XvOjjUv2ONaCiDNJ97VkL5hgjpCGgAKme0YiWFpGrQTLVBcMPnkrNWLWeT26iSLmj8NdiU8l0sRlGqvEXWRXP7mxODYNSAfBDRYVCappIGxZp2zODxKttqgfrrZpFECBRBokQ0sDRp1g9I84guahVGNk1HADw6ANV9SOmMkh8ZeWWZZCkirodHeTnQWKMH4hAcsbtgsr12PhZBV834XBzB0EGSfqxxNsV3H+E7TGoixokqS5JW7C2W9CeKINECGlMKINUz2hFGSQntQNaB7rhn2mPcauyA8KAwlSmo9TCLjbpUWxKMCZ/nPLKx6hYG02+LfzsmJ+rKEAyowZJHDRUZJDkH68uRrHVRQ1SQ8F/fWgUGyGkoaMAqZ6RyiABgIdoRXalmUO3La1BkpsoUsdMPYbpIm0DflbBz0QGSS7mER9aqTA9JUBDLtJuiMOmldTFRghpROhTrJ4R1yDJLQtharFavlILu9ikZo92VClNBhnl+qoMkqn9+BdNraNKEAyaMx2BOFNW3TxI5bzicWvYM0BqiLMR808FLTdBCGnoKECqZ7TiUWwyc4oIi7Tlj2d5BkkqQDLODLnxuvvKdfxRbPLHNhqhxwv+BDVIMmGPeKqBii494T6CYf6VAZK12RjzJoqkPyEDfnAsfq0JIaShoU+xekZqFJsUpZkZJAunQZKc78hBtFht/3ZB2DexD/d7WWUGSWotNj5xtws/+HMwYyZtqWOLgyn+KLYaZ5DMKtKmPyED/utDNUiEkIaOPsXqGfE3b36mhs/UTNoA8NHAtnDTOOC/Q9pb9PhSRdYVS41U/e6kFnaPVWWQhBdJ/hpgQNU6cwZa3rB/c4f5i9sqbq5eYhSbtRkkcwIrcxa0vV/QMH9CSGNCRdr1jHgUm7g424Cf6ZHKrLzwcBie79LU4uyJ1N6OosVqHZTCmbW5Im2FcLuXsxq5lWvKAdVkkMyYGNG4i80426RnEvMgWVukbcb9ZNZEvi8paRQbIaQRoU+xesY4gyQdIJmzFIU1XUtSd3EQ1SCJlx4x1DmpRIGTu5M4gyR8bvwCdJUZXWziAKmie008kzYvQGJVmS1rmJMd0lnah9mIUQaJENKY0KdYPcMPIty0DrLBT3VdbNaS7GIzyiApBYEUNw+SqCtOnP0yCpB42TJHQQZJrkhb3FbjYEq6SNu6t7nc+nMGzXxd0NyvdpfvAIRBX31GE0USQhoT+hSrZ/hdbHLda4AwO1TdhdwSkhkkpUKQTVFVrrlmeNhyvXQXm7uofsq4i42XQTKnBkm8pIrEXfgJnZoWaZsSHeaFbeN7UFcSD2WQCCGNCX2K1TPCDJJ8gCRcmsOGDZA4mEopnN/IECwZgiEuEBEFSGqVUhAEiYu0+V1sjlZ0sUnlmvg1SDUd5q/Ty0+R4KhSmDV30/2EZtImhDQm9ClWz/CH+fNHeYnV1kSCUkdVKBTCaQUUhgCp4nedXnoUm1KpEBRim5tBkntmRovyVlOkzQ/crFFmYqFfa7vtGjOaSZsQ0pjQp1g9w58oUusgPQcSIPy2bstQSS6Y4D+eUqGQ3FelNA6k+BkxkzVIZmQcxE2TWotNsFitYakRK9/l5SYySA1xrbTaJswg0fkhhDRsFCDVM/xuG42JDFJtXaBlu7ckuvSMAiTRUiNKpUKQSRBnFZx42SXB8zEjSAMqAkNTGaSaFmmXm8wg1V0A0DBKtIUjEWkmbUJIQ0efYvWYyQxSLV2g5Q4r1QVmtHisUiHYplIKRzOJgwpnuRok2baJutiUxvsyGxZpl5sYwk8TRBqjGiRCSGNCn2L1mKkaJEEXmw2rtJv7uUpuFxaFy3SxiWqVlAphBkncTn4XG3+5FLmnY9TFBoXRMW1ZpF1uYh07qkEyRqPYCCGNCX2K1WPiUV98tVWk3TncG58+095oiL5SEJBJt0E82k0cIIk5ySxWK8dookiJu0hmkKwt0jaRQarLGqSGkquimbQJIY0JfYrVY6YySLXp2U6heKipl2CbsItNOIqN264QzlqtUipMThjI72ITLFYrN1Gk6FDSa7Exo3/XTgapoYQtdceBMkiEkEaEPsXqsRb+0t1dYjadB6mSXjR7s1QNteQoNtEacaYulIIAyYwuNskibVEwJZgoUld7NUi27NasTkMp0hYM86cMEiGkgaNPsXrop5e7YHT3ZhjWpam9m8LhBwRckba4i00hXLOtui42fheiORkZcVCirCaDVNNh/u2aeJhoi3XHbMz455m62AghDZ1D9buQutajlR96tPKzaxvEGSQ+Q2AkPYqNn0Ey3dXCv4iqzBjFJq77UShMj2Kr6TD/Fx4Og54BH64/Y3QbxUfGDBk+lVJB80QRQho8+ppHJJmYI5EjOYqNHyApFHBRyxea84f2O5rRxWZU8ySxL7PhTNqOKiVGPdJM8ra6zCA5mziH9YkhcKbuNUJIY0CfZI1AbVyrTWWQDIznJVIYLTWS+GhrNPF0wjvxrY3uL8ggSUwjUN3jVRRpy9cgcUXatTBnkVwhuS3NfTYKrQPc8PHAdrX+WLZg6CalWbQJIY0BdbERSabCI26pEVF4XdG1wvtdoUCghxb7JvaRPI6vq4b7t7XD/MX3EqzFpqtZBsnenu4Ygqc7hti7GWbjMkgmpqcghJCGggIkIqlNoBsOX74teZuppUb4GZ3qRo8Femgx55n2cNE4mDXSTByQKSUiJKlh/rXR49NAY65aZahBUlMGiRDSCFCA1IB1CPVE8rVcxD8YaPNjvx3fGlpHFQZEBRvdVrXUiHFGR2pRW1OGdAo1Pr5sDZJUBkm4TbBYbWV/m3h6AFugAMmYissgUc89IaThowCpAVv9WlcUlengqrH9y+imdcSkfm0kb+O62ERBgnj0kq0zN0YBksQ+gi62ykrz2hlyThGSmOH1oSH+hJDGgD7JGjCVUlErwVF1THexVf1ube2PXAG08TB/43mQ+Bmk0vKKXxxrIaNBGSRjDpRBIoQ0IvRJRqxW3Sg2a+fCMXuYfzVF2mW62swgETGlkjJIhJDGw+6fZAsXLkR4eDi0Wi1iYmJw+PBh2X3LysrwwQcfICIiAlqtFlFRUdi8ebNgn+nTp3PDvw0/kZGRgn2Ki4sxduxY+Pj4wNXVFYMHD0ZWVlatPL/GxMdFDQDo1dofgDCQMQRD/HofqwMkme1GAVk1GSRDgFQbRcOUQDJGNUiEkMbErp9kK1asQGJiIqZNm4Zjx44hKioK8fHxyM7Oltx/8uTJ+Oabb7BgwQKcOXMGY8aMwaBBg3D8+HHBfg8++CAyMjK4n7179wpuHz9+PNatW4dVq1Zh9+7duHHjBp5++ulae56NxZ53e+Pvd3tza8QJskWVkYrCwiJtS0jVIBmvxUYZJHupGsVG55sQ0vDZ9ZNs7ty5GD16NBISEvDAAw9g0aJFcHZ2xg8//CC5/7Jly/Dee++hX79+aN68OV577TX069cPn332mWA/BwcHBAYGcj++vr7cbXl5eVi8eDHmzp2LPn36IDo6GkuWLMH+/ftx8ODBWn2+DZ2LxgGh3s7c7/yAxTAEv1a72JTG+xmvxVb179LKeZBqI0BqqHMr1SbKIBFCGhO7fZKVlpYiKSkJcXFxVY1RKhEXF4cDBw5I3qekpARarVawzcnJyShDdP78eQQHB6N58+YYPnw40tLSuNuSkpJQVlYmeNzIyEg0bdpU9nENj52fny/4ud/x4x9DwCDoYrNxkbZ4u1JhvKcgg1RemUGiIu06YZixnGbSJoQ0BnYLkG7evAmdToeAgADB9oCAAGRmZkreJz4+HnPnzsX58+eh1+uxbds2rFmzBhkZGdw+MTExWLp0KTZv3oyvv/4aly9fRvfu3XH37l0AQGZmJtRqNTw9Pc1+XACYNWsWPDw8uJ/QUOP5e+43SokuNn6Wx5zJHy2iMC7UFkcq/BnAbVWD9EafFgCAl2LDanScxq5rhA9a+ruif3vjubMIIaShaVC58Pnz56Nly5aIjIyEWq3GuHHjkJCQACXvqvzEE09gyJAhaN++PeLj47Fx40bk5uZi5cqVNXrsSZMmIS8vj/u5du1aTZ9OgyfsYlMYbbO2Z0suO1OxOK1CsJ94V8YYGGM4cuU28orKANS8i+2tuFbY9GZ3TBvwoKAtRKiFvxu2JfbEkxKTixJCSENjtwDJ19cXKpXKaPRYVlYWAgOlZ4b28/PD2rVrUVBQgKtXryIlJQWurq5o3ry57ON4enqiVatWuHDhAgAgMDAQpaWlyM3NNftxAUCj0cDd3V3wc7/jZ3O4UWz8xWpt3A+lUCiMuvWMapD0DD8fvIohiw7gfPY9ADUPkJRKBdoEuZu1oC4hhJDGwW4BklqtRnR0NHbs2MFt0+v12LFjB2JjY03eV6vVokmTJigvL8fq1avx1FNPye577949XLx4EUFBQQCA6OhoODo6Ch43NTUVaWlp1T4uEZIasaa0wSg2ueBDPGpNaqkRPQM+XH9WsI1GsRFCCLGUXZcaSUxMxIgRI9CpUyd06dIF8+bNQ0FBARISEgAAL730Epo0aYJZs2YBAA4dOoT09HR06NAB6enpmD59OvR6Pd59913umG+//TYGDBiAsLAw3LhxA9OmTYNKpcKwYcMAAB4eHhg1ahQSExPh7e0Nd3d3vP7664iNjcXDDz9c9yehAVNJdKdJFW7binjUmmQGiTGUVtYeGagdKNtDCCHEMnYNkIYOHYqcnBxMnToVmZmZ6NChAzZv3swVbqelpQnqi4qLizF58mRcunQJrq6u6NevH5YtWyYouL5+/TqGDRuGW7duwc/PD4888ggOHjwIPz8/bp/PP/8cSqUSgwcPRklJCeLj4/HVV1/V2fNuLPgF2YZgSdgNZd1x5e6mEB1TIbHvzXulRverjQwS9bARQkjjZvfFaseNG4dx48ZJ3rZr1y7B7z179sSZM2dMHu+3336r9jG1Wi0WLlyIhQsXmt1OYkyySNsGI9dki7QVCuMuNtG+p9LzjO5nywCpS7g3Dl+5jSHRNIqREEIaM7sHSKThkqo3snbuI3MoIOzCMywlw1dYWm50P1sGSMtHxyC3qAy+rhqbHZMQQkj9Q9WrxGpSo9j4QZO1oZKp+ymqOX6Zjhlts+XSFw4qJQVHhBByH6AAiVhNmEGq/L8N3lGyQ+glirTFykQF2gDgSEXahBBCLEQBErGaQjCKzXZdbPLxkXBQv1QNUrneOINEw/wJIYRYiq4cxGr8uENqHiRblyMpFMIicIVRyASUS2WQKEAihBBiIbpyEKspJTJINhnFZmJ7dRmk2q5BIoQQcn+gKwexmlSAxMeMYxXzyM2krah+LTbJGiRaXZ4QQoiFKEAiVhNM2lgHMycqoJAY5i/cR6oGSSp4I4QQQkyhAIlYjR94SCVpbD6TtkJ4q1JiLbaycuMMEi0sSwghxFIUIBGrVdfFZi35mbRFE0XCOINUpjcOkAghhBBLUYBErFbdnERWH9dEmbbwMY33kCrSJoQQQixFARKxmqraDJJtu7YqMkjC1WrF3Wc6iRokQgghxFIUIBGryXWxuWsrlviLDvOy6rgmJtIWDvM3kWsihBBCaoIWqyVWU0pMFAkAh9+PQ0FJOXysXLPMVJE2P2OklJgHiRBCCLEFCpCI1aSWGgEAraMKWkeV7R9PFDopFJRBIoQQUjuoi41YTSXK5tiKqVFsgt9BQ/gJIYTUDgqQiNWUghFltT+KTbxVKTFRJCGEEGILFCARq8l1sdX8wNU/nmE/io8IIYTUBgqQiNX4QZEtFqm1FK0gQgghpLZQgESsxg9QVDbtYpPZLk4gKWgYGyGEkNpBARKxGr/uyMGmS43I1SCJRrGButgIIYTUDgqQiNX4gYyT2vbD+o0fT/g7FWkTQgipLRQgEaupeO8eZxsGSPIrsYl+V5hat40QQgixHgVIxGr8LjYnG04MafY8SFSCRAghpJZQgESsJuxis92k7OYGPeasxebp7Fjj9hBCCLn/0FIjxGr8kWu27GKTIy7eNpVB+neP5igu0+HF2PBabxchhJDGhwIkYjX+wDWbdrFZMpO2zL7Bnk4Y0TXcZm0ihBByf6EuNmI1/uSQthzFJtvFJrEWm1wfmz0mriSEENJ4UIBErKaopQyS7OOJ50EysdSILedlIoQQcv+hAIlYre5rkMS/K2QnlbTlzN6EEELuPxQgEavxh/lrbdrFZl4Nktw2wMaL5xJCCLnvUIBErMaPY+pkokiJG+QSRRQgEUIIqQkKkIjV+BkkZ8faHxApNWKNAiRCCCG1gQIkYjV+DKJV2+6tZO5M2oD8lAAUIBFCCKkJCpCI1cp0jPu3sy1n0jZzHiRTKEAihBBSE3YPkBYuXIjw8HBotVrExMTg8OHDsvuWlZXhgw8+QEREBLRaLaKiorB582bBPrNmzULnzp3h5uYGf39/DBw4EKmpqYJ9evXqxY2AMvyMGTOmVp5fY1ZSruP+XRfD/KVSSLJdbDSKjRBCSA3YNUBasWIFEhMTMW3aNBw7dgxRUVGIj49Hdna25P6TJ0/GN998gwULFuDMmTMYM2YMBg0ahOPHj3P77N69G2PHjsXBgwexbds2lJWV4bHHHkNBQYHgWKNHj0ZGRgb38+mnn9bqc22MSsr13L9tmbGR7WKz4BgqFQVIhBBCrGfXAGnu3LkYPXo0EhIS8MADD2DRokVwdnbGDz/8ILn/smXL8N5776Ffv35o3rw5XnvtNfTr1w+fffYZt8/mzZsxcuRIPPjgg4iKisLSpUuRlpaGpKQkwbGcnZ0RGBjI/bi7u9fqc22Mist01e9kBctGsdE8SIQQQmzPbgFSaWkpkpKSEBcXV9UYpRJxcXE4cOCA5H1KSkqg1WoF25ycnLB3717Zx8nLywMAeHt7C7b/8ssv8PX1Rdu2bTFp0iQUFhaabG9JSQny8/MFP/c7fgbJluQzSBJdbDLHoJm0CSGE1ITdFqu9efMmdDodAgICBNsDAgKQkpIieZ/4+HjMnTsXPXr0QEREBHbs2IE1a9ZAp5POZOj1erz11lvo1q0b2rZty21//vnnERYWhuDgYJw4cQITJkxAamoq1qxZI9veWbNmYcaMGVY808arpKx2AiQ5lsyDRGuxEUIIqQm7BUjWmD9/PkaPHo3IyEgoFApEREQgISFBtktu7NixOHXqlFGG6dVXX+X+3a5dOwQFBaFv3764ePEiIiIiJI81adIkJCYmcr/n5+cjNDTUBs+q4eIXaduWJTNp0zB/Qgghtme3LjZfX1+oVCpkZWUJtmdlZSEwMFDyPn5+fli7di0KCgpw9epVpKSkwNXVFc2bNzfad9y4cVi/fj127tyJkJAQk22JiYkBAFy4cEF2H41GA3d3d8HP/a64ljJIFs2DRBNFEkIIqQV2C5DUajWio6OxY8cObpter8eOHTsQGxtr8r5arRZNmjRBeXk5Vq9ejaeeeoq7jTGGcePG4ffff8dff/2FZs2aVduW5ORkAEBQUJB1T+Y+Na5PCwDA8zFN6+TxpAqyZddioyJtQgghNWDXLrbExESMGDECnTp1QpcuXTBv3jwUFBQgISEBAPDSSy+hSZMmmDVrFgDg0KFDSE9PR4cOHZCeno7p06dDr9fj3Xff5Y45duxYLF++HH/88Qfc3NyQmZkJAPDw8ICTkxMuXryI5cuXo1+/fvDx8cGJEycwfvx49OjRA+3bt6/7k9CAtW3igbMfPA4nG67DBlg2nJ8ySIQQQmqDXQOkoUOHIicnB1OnTkVmZiY6dOiAzZs3c4XbaWlpUCqrklzFxcWYPHkyLl26BFdXV/Tr1w/Lli2Dp6cnt8/XX38NoGIySL4lS5Zg5MiRUKvV2L59OxeMhYaGYvDgwZg8eXKtP9/GyNbBESA/dF+hkAqIqAaJEEKI7dm9SHvcuHEYN26c5G27du0S/N6zZ0+cOXPG5PEYYyZvDw0Nxe7duy1qI6lbsvMgWbBYLQ3zJ4QQUhN2X2qEEHNJL1YrjYb5E0IIqQkKkEi9Y6q+WpwglOuOowwSIYSQmqAAidQ7lqzFJptBolFshBBCaoACJNJgSBVpy9Yg0WK1hBBCaoACJFLvyM2ObUmRNs2DRAghpCbMHsXGX2ajOnPnzrWqMYQAkO03syTmoWH+hBBCasLsAOn48eOC348dO4by8nK0bt0aAHDu3DmoVCpER0fbtoXkvmPRRJE0DxIhhJBaYHaAtHPnTu7fc+fOhZubG3788Ud4eXkBAO7cuYOEhAR0797d9q0kBDIj1mTiIBrmTwghpCasqkH67LPPMGvWLC44AgAvLy989NFH+Oyzz2zWOHJ/kp1J28xtAA3zJ4QQUjNWBUj5+fnIyckx2p6Tk4O7d+/WuFHk/iY7k7ZUAkkmmKJh/oQQQmrCqgBp0KBBSEhIwJo1a3D9+nVcv34dq1evxqhRo/D000/buo2EAKAMEiGEkLpj1VpsixYtwttvv43nn38eZWVlFQdycMCoUaMwZ84cmzaQ3H9kJ4qUuEF2mD8FSIQQQmrA4gBJp9Ph6NGj+PjjjzFnzhxcvHgRABAREQEXFxebN5Dcf2TnQZKs0TbeqFTId70RQggh5rA4QFKpVHjsscdw9uxZNGvWDO3bt6+NdpH7mEVLjUhspOwRIYSQmrKqBqlt27a4dOmSrdtCiGlSXWwSu1GARAghpKasCpA++ugjvP3221i/fj0yMjKQn58v+CGkJmRHsZm5kZYZIYQQUlNWFWn369cPAPDkk08Kaj0YY1AoFNDpdLZpHbk/mVhqxGixWomdKYNECCGkpqwKkPizahNSVxRQgDHRNqpBIoQQUgusCpB69uxp63YQwrFsFJsxldKqnmNCCCGEY1WAZFBYWIi0tDSUlpYKttPINlITlo1ik+pis217CCGE3H+sCpBycnKQkJCATZs2Sd5ONUikJixbasR4m9qBIiRCCCE1Y9WV5K233kJubi4OHToEJycnbN68GT/++CNatmyJP//809ZtJARARdebOQPUwrxpwlJCCCE1Y1UG6a+//sIff/yBTp06QalUIiwsDI8++ijc3d0xa9Ys9O/f39btJPcR2VmwzaxBauZLARIhhJCasSqDVFBQAH9/fwCAl5cXcnJyAADt2rXDsWPHbNc6cl+q6Uzazf0oQCKEEFIzVgVIrVu3RmpqKgAgKioK33zzDdLT07Fo0SIEBQXZtIGE8ImH+UuFTZRBIoQQUlNWdbG9+eabyMjIAABMmzYNjz/+OH755Reo1WosXbrUlu0j9yH5Im2JpUYkdo7wc7VtgwghhNx3rAqQXnjhBe7f0dHRuHr1KlJSUtC0aVP4+vrarHHk/mSqi814Jm1jwZ5Otm4SIYSQ+4xVXWzihWqdnZ3RsWNHCo6IjVgwUSRvY/sQD/z+n640kzYhhJAasyqD1KJFC4SEhKBnz57o1asXevbsiRYtWti6bYQIVDeTdveWvnioqVedtYcQQkjjZVUG6dq1a5g1axacnJzw6aefolWrVggJCcHw4cPx/fff27qN5D4j38VmugZJbokSQgghxFJWBUhNmjTB8OHD8e233yI1NRWpqamIi4vDypUr8e9//9vWbST3GYtm0ubtbc4kkoQQQog5rOpiKywsxN69e7Fr1y7s2rULx48fR2RkJMaNG4devXrZuImEyBNmkAghhBDbsCpA8vT0hJeXF4YPH46JEyeie/fu8PKi2g9iG3IzacvOsF21Qy20hhBCyP3IqgCpX79+2Lt3L3777TdkZmYiMzMTvXr1QqtWrWzdPnIfku1ik9pGGSRCCCG1wKoapLVr1+LmzZvYvHkzYmNjsXXrVnTv3p2rTSKkJmSLtKkGiRBCSB2xKkAyaNeuHbp164bY2Fh07twZ2dnZWLFihUXHWLhwIcLDw6HVahETE4PDhw/L7ltWVoYPPvgAERER0Gq1iIqKwubNmy0+ZnFxMcaOHQsfHx+4urpi8ODByMrKsqjdpO5VN4pNSRESIYQQG7EqQJo7dy6efPJJ+Pj4ICYmBr/++itatWqF1atXcwvXmmPFihVITEzEtGnTcOzYMURFRSE+Ph7Z2dmS+0+ePBnffPMNFixYgDNnzmDMmDEYNGgQjh8/btExx48fj3Xr1mHVqlXYvXs3bty4gaefftqaU0FqgdxwfemJIvn3I4QQQmxDwZjx8p/V6dy5MzdJZPfu3eHh4WHVg8fExKBz58748ssvAQB6vR6hoaF4/fXXMXHiRKP9g4OD8f7772Ps2LHctsGDB8PJyQk///yzWcfMy8uDn58fli9fjmeeeQYAkJKSgjZt2uDAgQN4+OGHzWp7fn4+PDw8kJeXB3d3d6ueP5F2Kj0P/1qw12j718M7Yuams7h2uwgAcGV2f6Rk5uPxeX8DAN5+rBXG9WlZp20lhBDSsJh7/baqSPvIkSNWN8ygtLQUSUlJmDRpErdNqVQiLi4OBw4ckLxPSUkJtFqtYJuTkxP27t1r9jGTkpJQVlaGuLg4bp/IyEg0bdrUZIBUUlKCkpIS7vf8/HwLnzGpqeprkCiHRAghxDasrkH6+++/8cILLyA2Nhbp6ekAgGXLlnHBSnVu3rwJnU6HgIAAwfaAgABkZmZK3ic+Ph5z587F+fPnodfrsW3bNqxZswYZGRlmHzMzMxNqtRqenp5mPy4AzJo1Cx4eHtxPaGioWc+T2JLCqPuNYiJCCCG1waoAafXq1YiPj4eTkxOOHz/OZVby8vIwc+ZMmzaQb/78+WjZsiUiIyOhVqsxbtw4JCQkQKmsUa25WSZNmoS8vDzu59q1a7X+mPcrU6PYGIQ9wgrR7YQQQogtWBVZfPTRR1i0aBG+++47ODo6ctu7deuGY8eOmXUMX19fqFQqo9FjWVlZCAwMlLyPn58f1q5di4KCAly9ehUpKSlwdXVF8+bNzT5mYGAgSktLkZuba/bjAoBGo4G7u7vgh9QO2SJtqW20FhshhJBaYFWAlJqaih49ehht9/DwMAo85KjVakRHR2PHjh3cNr1ejx07diA2NtbkfbVaLZo0aYLy8nKsXr0aTz31lNnHjI6OhqOjo2Cf1NRUpKWlVfu4xL6ka4xoHiRCCCG2Z1WRdmBgIC5cuIDw8HDB9r1793LZHHMkJiZixIgR6NSpE7p06YJ58+ahoKAACQkJAICXXnoJTZo0waxZswAAhw4dQnp6Ojp06ID09HRMnz4der0e7777rtnH9PDwwKhRo5CYmAhvb2+4u7vj9ddfR2xsrNkj2Ejtku1iq2ZfJQVIhBBCbMSqAGn06NF488038cMPP0ChUODGjRs4cOAA/u///g9Tp041+zhDhw5FTk4Opk6diszMTHTo0AGbN2/miqzT0tIE9UXFxcWYPHkyLl26BFdXV/Tr1w/Lli0TFFxXd0wA+Pzzz6FUKjF48GCUlJQgPj4eX331lTWngtQCUzVIRkXagn9ThEQIIcQ2rJoHiTGGmTNnYtasWSgsLARQUaPzzjvvYNKkSXBycrJ5Q+sbmgep9vDnNuL7YWQnTP/zDNJuV7znrszuj8s3C9D7v7sAAJP7t8Er3c3PYBJCCLn/mHv9tqoGSaFQ4P3338ft27dx6tQpHDx4EDk5OfDw8ECzZs2sbjQhgKkibQWiQj1F2wghhBDbs6iLraSkBNOnT8e2bdu4jNHAgQOxZMkSDBo0CCqVCuPHj6+ttpL7hGyxtQL48KkH0cTTCU93bGK0L00USQghxFYsCpCmTp2Kb775BnFxcdi/fz+GDBmChIQEHDx4EJ999hmGDBkClUpVW20l9wlTYY6nsxoTn4jk7csbxVaLbSKEEHJ/sShAWrVqFX766Sc8+eSTOHXqFNq3b4/y8nL8888/9O2d1Lpq50GityAhhBAbsagG6fr164iOjgYAtG3bFhqNBuPHj6fgiNiU/Cg20+8zehcSQgixFYsCJJ1OB7Vazf3u4OAAV1dXmzeK3O+snEmbAnVCCCE2YlEXG2MMI0eOhEajAVAxL9GYMWPg4uIi2G/NmjW2ayEhlaTiH35QRBNFEkIIsRWLAqQRI0YIfn/hhRds2hhCAOO6IsNMXVLD/wVbKINECCHERiwKkJYsWVJb7SCEoxD92zCTaXXxD4VHhBBCbMWqiSIJqU3CbjPTw/hpFBshhJDaQAESqdeUggjI+HbhPEgUIRFCCLENCpBIvSPoYhPERxI1SJRBIoQQUgsoQCL1jlzQIzmKTebfhBBCSE1QgETqtepqkEAZJEIIIbWAAiRS7/C70gQBkkQEJKhBogiJEEKIjVCAROodubps6YkipfclhBBCaoICJFKvVRcACQMoCpEIIYTYBgVIpF5TKvldaMa3U1BECCGkNlCAROodfswjmAepuqVGCCGEEBuhAInUOwqZkWvV1SARQgghtkIBEqnXqq9BogiJEEKI7VGAROoducJryXojio8IIYTUAgqQSL0jO8y/mn0JIYQQW6EAidQ78hNFSu0r/W9CCCGkJihAIvWaUpBNMh0CUTaJEEKIrVCAROod4QK11QVFFBURQgixPQqQSL0jN7SfarQJIYTUFQqQSL2mrDaDVEcNIYQQcl+hAInUP4KZtHmbJTNIFCERQgixPQqQSL3DD3qEs2pLLDVC8REhhJBaQAESqXfk6o4oGCKEEFJXKEAi9Vq18yBR0EQIIaQWUIBE6h25yR8lu9hgOoAihBBCrEEBEql3FDJZI8ogEUIIqSsUIJF6TZAhkrydEEIIsT27B0gLFy5EeHg4tFotYmJicPjwYZP7z5s3D61bt4aTkxNCQ0Mxfvx4FBcXc7eHh4dDoVAY/YwdO5bbp1evXka3jxkzptaeI7GMRRNFUgqJEEJILXCw54OvWLECiYmJWLRoEWJiYjBv3jzEx8cjNTUV/v7+RvsvX74cEydOxA8//ICuXbvi3LlzGDlyJBQKBebOnQsAOHLkCHQ6HXefU6dO4dFHH8WQIUMExxo9ejQ++OAD7ndnZ+daepbEUvIxj1QNEiGEEGJ7dg2Q5s6di9GjRyMhIQEAsGjRImzYsAE//PADJk6caLT//v370a1bNzz//PMAKrJFw4YNw6FDh7h9/Pz8BPeZPXs2IiIi0LNnT8F2Z2dnBAYG2vopERuQnQeJapAIIYTUEbt1sZWWliIpKQlxcXFVjVEqERcXhwMHDkjep2vXrkhKSuK64S5duoSNGzeiX79+so/x888/4+WXXzbqivnll1/g6+uLtm3bYtKkSSgsLDTZ3pKSEuTn5wt+SO2TG9HGbaMIiRBCSC2wWwbp5s2b0Ol0CAgIEGwPCAhASkqK5H2ef/553Lx5E4888ggYYygvL8eYMWPw3nvvSe6/du1a5ObmYuTIkUbHCQsLQ3BwME6cOIEJEyYgNTUVa9askW3vrFmzMGPGDMueJLGO7ESRFAwRQgipG3btYrPUrl27MHPmTHz11VeIiYnBhQsX8Oabb+LDDz/ElClTjPZfvHgxnnjiCQQHBwu2v/rqq9y/27Vrh6CgIPTt2xcXL15ERESE5GNPmjQJiYmJ3O/5+fkIDQ210TMjfLIzaVd3P6pIIoQQYiN2C5B8fX2hUqmQlZUl2J6VlSVbGzRlyhS8+OKLeOWVVwBUBDcFBQV49dVX8f7770OprOoxvHr1KrZv324yK2QQExMDALhw4YJsgKTRaKDRaMx6bsR2LJkIkhJMhBBCbMVuNUhqtRrR0dHYsWMHt02v12PHjh2IjY2VvE9hYaEgCAIAlUoFAGCMCbYvWbIE/v7+6N+/f7VtSU5OBgAEBQVZ8hRILZEd5k8ZIkIIIXXErl1siYmJGDFiBDp16oQuXbpg3rx5KCgo4Ea1vfTSS2jSpAlmzZoFABgwYADmzp2Lhx56iOtimzJlCgYMGMAFSkBFoLVkyRKMGDECDg7Cp3jx4kUsX74c/fr1g4+PD06cOIHx48ejR48eaN++fd09eSJLMHJNsL3u20IIIeT+ZNcAaejQocjJycHUqVORmZmJDh06YPPmzVzhdlpamiBjNHnyZCgUCkyePBnp6enw8/PDgAED8PHHHwuOu337dqSlpeHll182eky1Wo3t27dzwVhoaCgGDx6MyZMn1+6TJWYTxEEUFRFCCLEDBRP3TRGz5Ofnw8PDA3l5eXB3d7d3cxqVgpJyPDhtCwCgQ6gnkq/lAgD2TuiNEC/jCT3DJ24AAMx/rgOe6tCkztpJCCGk4TH3+m33pUYIEZNLGtEwf0IIIXWFAiRS78iNXKPwiBBCSF2hAInUaxQUEUIIsQcKkEi9Izd7NvWwEUIIqSsUIJF6TbgWG0VIhBBC6gYFSKTekV1qhOIjQgghdYQCJFKvCQq27dgOQggh9xcKkEi9I+hKE/axEUIIIXWCAiRS78gN7acaJEIIIXWFAiRSr1ENEiGEEHugAInUO3JZI4qPCCGE1BUKkEi9w5/7iIFJbq/ufoQQQkhNUIBE6h25MKe68IfCI0IIIbZCARKp16gwmxBCiD1QgETqHeopI4QQYm8UIJF6h2qJCCGE2BsFSKTRaBXgZu8mEEIIaSQc7N0AQmpqe2JPZOYVo3UgBUiEEEJsgwIkUq/xh/nLaeHvihb+rnXQGkIIIfcL6mIjhBBCCBGhAInUazTMnxBCiD1QgETqNZWSt9QIxUqEEELqCNUgkXrNy0WNZ6JDoADg6ay2d3MIIYTcJyhAIvXef4dE2bsJhBBC7jPUxUYIIYQQIkIBEqnXGKt+mD8hhBBiaxQgEUIIIYSIUIBE6jVal40QQog9UIBECCGEECJCARIhhBBCiAgFSIQQQgghIhQgEUIIIYSIUIBE6jUa5k8IIcQeKEAihBBCCBGhAInUazTMnxBCiD3YPUBauHAhwsPDodVqERMTg8OHD5vcf968eWjdujWcnJwQGhqK8ePHo7i4mLt9+vTpUCgUgp/IyEjBMYqLizF27Fj4+PjA1dUVgwcPRlZWVq08P0IIIYQ0PHYNkFasWIHExERMmzYNx44dQ1RUFOLj45GdnS25//LlyzFx4kRMmzYNZ8+exeLFi7FixQq89957gv0efPBBZGRkcD979+4V3D5+/HisW7cOq1atwu7du3Hjxg08/fTTtfY8CSGEENKwONjzwefOnYvRo0cjISEBALBo0SJs2LABP/zwAyZOnGi0//79+9GtWzc8//zzAIDw8HAMGzYMhw4dEuzn4OCAwMBAycfMy8vD4sWLsXz5cvTp0wcAsGTJErRp0wYHDx7Eww8/bMunSAghhJAGyG4ZpNLSUiQlJSEuLq6qMUol4uLicODAAcn7dO3aFUlJSVw33KVLl7Bx40b069dPsN/58+cRHByM5s2bY/jw4UhLS+NuS0pKQllZmeBxIyMj0bRpU9nHJYQQQsj9xW4ZpJs3b0Kn0yEgIECwPSAgACkpKZL3ef7553Hz5k088sgjYIyhvLwcY8aMEXSxxcTEYOnSpWjdujUyMjIwY8YMdO/eHadOnYKbmxsyMzOhVqvh6elp9LiZmZmy7S0pKUFJSQn3e35+vhXPmliKhvkTQgixB7sXaVti165dmDlzJr766iscO3YMa9aswYYNG/Dhhx9y+zzxxBMYMmQI2rdvj/j4eGzcuBG5ublYuXJljR571qxZ8PDw4H5CQ0Nr+nQIIYQQUk/ZLUDy9fWFSqUyGj2WlZUlWz80ZcoUvPjii3jllVfQrl07DBo0CDNnzsSsWbOg1+sl7+Pp6YlWrVrhwoULAIDAwECUlpYiNzfX7McFgEmTJiEvL4/7uXbtmgXPlliLhvkTQgixB7sFSGq1GtHR0dixYwe3Ta/XY8eOHYiNjZW8T2FhIZRKYZNVKhUA+a6Ye/fu4eLFiwgKCgIAREdHw9HRUfC4qampSEtLk31cANBoNHB3dxf8EEIIIaRxsusotsTERIwYMQKdOnVCly5dMG/ePBQUFHCj2l566SU0adIEs2bNAgAMGDAAc+fOxUMPPYSYmBhcuHABU6ZMwYABA7hA6e2338aAAQMQFhaGGzduYNq0aVCpVBg2bBgAwMPDA6NGjUJiYiK8vb3h7u6O119/HbGxsTSCjRBCCCEA7BwgDR06FDk5OZg6dSoyMzPRoUMHbN68mSvcTktLE2SMJk+eDIVCgcmTJyM9PR1+fn4YMGAAPv74Y26f69evY9iwYbh16xb8/PzwyCOP4ODBg/Dz8+P2+fzzz6FUKjF48GCUlJQgPj4eX331Vd09cUIIIYTUawpGw4Sskp+fDw8PD+Tl5VF3Wy0In7gBADAgKhgLhj1k59YQQghpLMy9fjeoUWzk/kPxOyGEEHugAIkQQgghRIQCJFKv0TB/Qggh9kABEiGEEEKICAVIhBBCCCEiFCARQgghhIhQgEQIIYQQIkIBEqnXaJg/IYQQe6AAiRBCCCFEhAIkUq/RMH9CCCH2QAESIYQQQogIBUiEEEIIISIUIBFCCCGEiFCARAghhBAiQgESqddomD8hhBB7oACJEEIIIUSEAiRSr9Ewf0IIIfZAARIhhBBCiAgFSIQQQgghIhQgEUIIIYSIUIBECCGEECJCARIhhBBCiAgFSIQQQgghIhQgEUIIIYSIUIBECCGEECJCARIhhBBCiAgFSIQQQgghIhQgEUIIIYSIUIBECCGEECJCARIhhBBCiAgFSIQQQgghIhQgEUIIIYSIUIBECCGEECJCARIhhBBCiAgFSIQQQgghInYPkBYuXIjw8HBotVrExMTg8OHDJvefN28eWrduDScnJ4SGhmL8+PEoLi7mbp81axY6d+4MNzc3+Pv7Y+DAgUhNTRUco1evXlAoFIKfMWPG1MrzI4QQQkjDY9cAacWKFUhMTMS0adNw7NgxREVFIT4+HtnZ2ZL7L1++HBMnTsS0adNw9uxZLF68GCtWrMB7773H7bN7926MHTsWBw8exLZt21BWVobHHnsMBQUFgmONHj0aGRkZ3M+nn35aq8+VEEIIIQ2Hgz0ffO7cuRg9ejQSEhIAAIsWLcKGDRvwww8/YOLEiUb779+/H926dcPzzz8PAAgPD8ewYcNw6NAhbp/NmzcL7rN06VL4+/sjKSkJPXr04LY7OzsjMDCwNp4WIYQQQho4u2WQSktLkZSUhLi4uKrGKJWIi4vDgQMHJO/TtWtXJCUlcd1wly5dwsaNG9GvXz/Zx8nLywMAeHt7C7b/8ssv8PX1Rdu2bTFp0iQUFhbW9CkRQgghpJGwWwbp5s2b0Ol0CAgIEGwPCAhASkqK5H2ef/553Lx5E4888ggYYygvL8eYMWMEXWx8er0eb731Frp164a2bdsKjhMWFobg4GCcOHECEyZMQGpqKtasWSPb3pKSEpSUlHC/5+fnW/J0CSGEENKA2LWLzVK7du3CzJkz8dVXXyEmJgYXLlzAm2++iQ8//BBTpkwx2n/s2LE4deoU9u7dK9j+6quvcv9u164dgoKC0LdvX1y8eBERERGSjz1r1izMmDHDtk+IEEIIIfWS3QIkX19fqFQqZGVlCbZnZWXJ1gZNmTIFL774Il555RUAFcFNQUEBXn31Vbz//vtQKqt6DMeNG4f169djz549CAkJMdmWmJgYAMCFCxdkA6RJkyYhMTGR+z0/Px+hoaHVP1FC7iOGzK5Op7N3Uwgh9ymVSgUHBwcoFIoaHcduAZJarUZ0dDR27NiBgQMHAqjoEtuxYwfGjRsneZ/CwkJBEARUnAig4oPZ8P/XX38dv//+O3bt2oVmzZpV25bk5GQAQFBQkOw+Go0GGo2m2mMRcr8qLS1FRkYG1fMRQuzO2dkZQUFBUKvVVh/Drl1siYmJGDFiBDp16oQuXbpg3rx5KCgo4Ea1vfTSS2jSpAlmzZoFABgwYADmzp2Lhx56iOtimzJlCgYMGMAFSmPHjsXy5cvxxx9/wM3NDZmZmQAADw8PODk54eLFi1i+fDn69esHHx8fnDhxAuPHj0ePHj3Qvn17+5wIQho4vV6Py5cvQ6VSITg4GGq1usbf3gghxFKMMZSWliInJweXL19Gy5YtjRIr5rJrgDR06FDk5ORg6tSpyMzMRIcOHbB582aucDstLU3wxCZPngyFQoHJkycjPT0dfn5+GDBgAD7++GNun6+//hpAxWSQfEuWLMHIkSOhVquxfft2LhgLDQ3F4MGDMXny5Np/woQ0UqWlpdDr9QgNDYWzs7O9m0MIuY85OTnB0dERV69eRWlpKbRarVXHUTBD3xSxSH5+Pjw8PJCXlwd3d3d7N6fRCZ+4AQAwICoYC4Y9ZOfWkOoUFxfj8uXLaNasmdUfRoQQYiumPpPMvX7bfakRQgghhJD6hgIkQgghJl25cgUKhYIb0HK/UCgUWLt2rb2bQeyEAiRCyH1t5MiRsgtWjx07FgqFAiNHjqz7hoksXbpUsMC2q6sroqOjTU5wK2XXrl1QKBTIzc2tnYbyhIeHc+11dnZGu3bt8P3339f64xLLMcYwdepUBAUFwcnJCXFxcTh//rzJ+9y9exdvvfUWwsLC4OTkhK5du+LIkSOCfbKysjBy5EgEBwfD2dkZjz/+uOC4huBb6mfVqlXcfjt27EDXrl3h5uaGwMBATJgwAeXl5bY9CSIUIBFC7nuhoaH47bffUFRUxG0rLi7G8uXL0bRpUzu2TMjd3Z1bYPv48eOIj4/Hs88+i9TUVHs3TdYHH3yAjIwMnDp1Ci+88AJGjx6NTZs22btZnNLSUns3oV749NNP8cUXX2DRokU4dOgQXFxcEB8fj+LiYtn7vPLKK9i2bRuWLVuGkydP4rHHHkNcXBzS09MBVARdAwcOxKVLl/DHH3/g+PHjCAsLQ1xcHLeAfGhoqGDh+IyMDMyYMQOurq544oknAAD//PMP+vXrh8cffxzHjx/HihUr8Oeff0qu2WpTjFglLy+PAWB5eXn2bkqjFDZhPQubsJ6NW37M3k0hZigqKmJnzpxhRUVF9m6KxUaMGMGeeuop1rZtW/bzzz9z23/55RfWvn179tRTT7ERI0Zw23U6HZs5cyYLDw9nWq2WtW/fnq1atYq7vby8nL388svc7a1atWLz5s2TfMw5c+awwMBA5u3tzf7zn/+w0tJS2XYuWbKEeXh4CLbpdDrm6OjIVq5cyW376aefWHR0NHN1dWUBAQFs2LBhLCsrizHG2OXLlxkAwY/huel0OvbJJ5+wiIgIplarWWhoKPvoo48E91u9ejXr1asXc3JyYu3bt2f79+83eW7DwsLY559/Ltjm7e3Nxo8fz/1+584dNmrUKObr68vc3NxY7969WXJyMmOMsdzcXKZUKtmRI0e4Nnp5ebGYmBju/suWLWMhISHc7++++y5r2bIlc3JyYs2aNWOTJ08WnNdp06axqKgo9t1337Hw8HCmUCgYY4ydO3eOde/enWk0GtamTRu2detWBoD9/vvvjDHGSkpK2NixY1lgYCDTaDSsadOmbObMmSafP9/OnTsZALZ582bWoUMHptVqWe/evVlWVhbbuHEji4yMZG5ubmzYsGGsoKCAu9+mTZtYt27dmIeHB/P29mb9+/dnFy5c4G7/8ccfmYuLCzt37hy37bXXXmOtW7cWHMcUvV7PAgMD2Zw5c7htubm5TKPRsF9//VXyPoWFhUylUrH169cLtnfs2JG9//77jDHGUlNTGQB26tQp7nadTsf8/PzYd999J9ueDh06sJdffpn7fdKkSaxTp06Cff7880+m1WpZfn6+5DFMfSaZe/2mDBIhpFYwxlBYWm6XH2bF4NyXX34ZS5Ys4X7/4YcfuDnZ+GbNmoWffvoJixYtwunTpzF+/Hi88MIL2L17N4CKOaFCQkKwatUqnDlzBlOnTsV7772HlStXCo6zc+dOXLx4ETt37sSPP/6IpUuXYunSpWa3V6fT4ccffwQAdOzYkdteVlaGDz/8EP/88w/Wrl2LK1eucF2EoaGhWL16NQAgNTUVGRkZmD9/PoCK1QJmz56NKVOm4MyZM1i+fLnRWpnvv/8+3n77bSQnJ6NVq1YYNmyY2d0cer0eq1evxp07dwST9w0ZMgTZ2dnYtGkTkpKS0LFjR/Tt2xe3b9+Gh4cHOnTogF27dgEATp48CYVCgePHj+PevXsAgN27d6Nnz57c8dzc3LB06VKcOXMG8+fPx3fffYfPP/9c0JYLFy5g9erVWLNmDZKTk6HX6/H0009DrVbj0KFDWLRoESZMmCC4zxdffIE///wTK1euRGpqKn755ReEh4eb9dz5pk+fji+//BL79+/HtWvX8Oyzz2LevHlYvnw5NmzYgK1bt2LBggXc/gUFBUhMTMTRo0exY8cOKJVKDBo0CHq9HkDFfIH9+vXD8OHDUV5ejg0bNuD777/HL7/8wk25MX36dJNtvXz5MjIzMwWLx3t4eCAmJkZ28XjDjPniEWJOTk7c8l6G9Uv5+yiVSmg0GqMlwAySkpKQnJyMUaNGcdtKSkokH6e4uBhJSUmyz6vGTIZPRBZlkGoXZZAaFqlvawUlZdzrWNc/BSVlZrfdkM3Jzs5mGo2GXblyhV25coVptVqWk5MjyCAVFxczZ2dno8zJqFGj2LBhw2QfY+zYsWzw4MGCxwwLC2Pl5eXctiFDhrChQ4fKHmPJkiUMAHNxcWEuLi5MqVQyjUbDlixZYvL5HTlyhAFgd+/eZYxVZTLu3LnD7ZOfn880Go3st3pDBun777/ntp0+fZoBYGfPnpV97LCwMKZWq5mLiwtzcHBgAJi3tzc7f/48Y4yxv//+m7m7u7Pi4mLB/SIiItg333zDGGMsMTGR9e/fnzHG2Lx589jQoUNZVFQU27RpE2OMsRYtWrBvv/1Wtg1z5sxh0dHR3O/Tpk1jjo6OLDs7m9u2ZcsW5uDgwNLT07ltmzZtEmSQXn/9ddanTx+m1+tlH8sUw3nfvn07t23WrFkMALt48SK37d///jeLj4+XPU5OTg4DwE6ePMltu337NgsJCWGvvfYaCwgIYB9//LHgPgsWLGB9+vSRPea+ffsYAHbjxg3B9iFDhrBnn31W9n6xsbGsZ8+eLD09nZWXl7Nly5YxpVLJWrVqxRhjrLS0lDVt2pQNGTKE3b59m5WUlLDZs2czAOyxxx6TPOZrr73G2rRpI9i2ZcsWplQq2fLly1l5eTm7fv066969OwPAli9fLnkcyiARQoiN+Pn5oX///li6dCmWLFmC/v37w9fXV7DPhQsXUFhYiEcffRSurq7cz08//YSLFy9y+y1cuBDR0dHw8/ODq6srvv32W6SlpQmO9eCDD3IrAAAVSx1lZ2ebbKObmxuSk5ORnJyM48ePY+bMmRgzZgzWrVvH7ZOUlIQBAwagadOmcHNz47Ir4sfnO3v2LEpKStC3b1+Tj89fbcCwNFN1bX7nnXeQnJyMv/76CzExMfj888/RokULABW1Jffu3YOPj4/gfF6+fJk7nz179sTevXuh0+mwe/du9OrVC7169cKuXbtw48YNXLhwQTAx8IoVK9CtWzcEBgbC1dUVkydPNnruYWFh8PPzEzz/0NBQBAcHc9tiY2MF9xk5ciSSk5PRunVrvPHGG9i6davJ5y2Hfw4DAgLg7OyM5s2bC7bxz+n58+cxbNgwNG/eHO7u7lwmiP+cvLy8sHjxYnz99deIiIgwqs0ZN24cduzYYVV7TVm2bBkYY2jSpAk0Gg2++OILDBs2jJvg2dHREWvWrMG5c+fg7e0NZ2dn7Ny5E0888YTk7NZFRUVYvny5IHsEAI899hjmzJmDMWPGQKPRoFWrVujXrx8AWD1LtjnsOpM2IaTxcnJU4cwH8XZ7bGu8/PLL3FqQCxcuNLrd0K2zYcMGNGnSRHCbYa3G3377DW+//TY+++wzxMbGws3NDXPmzMGhQ4cE+zs6Ogp+VygUXLeJHKVSyQUXQMXFduvWrfjkk08wYMAAFBQUID4+HvHx8fjll1/g5+eHtLQ0xMfHmyxGdnJyMvm4Um02LCVTXZt9fX3RokULtGjRAqtWrUK7du3QqVMnPPDAA7h37x6CgoK4LjQ+T09PAECPHj1w9+5dHDt2DHv27MHMmTMRGBiI2bNnIyoqCsHBwWjZsiUA4MCBAxg+fDhmzJiB+Ph4eHh44LfffsNnn30mOLaLi4tZz5evY8eOuHz5MjZt2oTt27fj2WefRVxcHP73v/9ZdBzxOazufTBgwACEhYXhu+++Q3BwMPR6Pdq2bWv0eu7ZswcqlQoZGRkoKCiAm5ub2W0yLBCflZUlWJM0KysLHTp0kL1fREQEdu/ejYKCAuTn5yMoKAhDhw4VBHzR0dFITk5GXl4eSktL4efnh5iYGHTq1MnoeP/73/9QWFiIl156yei2xMREjB8/HhkZGfDy8sKVK1cwadIkwWPZGgVIhJBaoVAo4KxuWB8xjz/+OEpLS6FQKBAfbxzcPfDAA9BoNEhLSxPUvfDt27cPXbt2xX/+8x9uGz+7ZGsqlYobfZeSkoJbt25h9uzZCA0NBQAcPXpUsL+h/ken03HbWrZsCScnJ+zYsQOvvPJKrbU1NDQUQ4cOxaRJk/DHH3+gY8eOyMzMhIODg2yNjKenJ9q3b48vv/wSjo6OiIyMhL+/P4YOHYr169cLXof9+/cjLCwM77//Prft6tWr1barTZs2uHbtGjIyMrgA4eDBg0b7ubu7Y+jQoRg6dCieeeYZPP7447h9+za8vb0tPBPmuXXrFlJTU/Hdd9+he/fuACBZu7N//3588sknWLduHSZMmIBx48Zx9WnmaNasGQIDA7Fjxw4uIMrPz8ehQ4fw2muvVXt/FxcXuLi44M6dO9iyZQs+/fRTo308PDwAVGTEjh49ig8//NBon8WLF+PJJ58UZPf4FAoFl+X79ddfERoaKqi/s7WG9elF7juOKlrwlNQdlUqFs2fPcv8Wc3Nzw9tvv43x48dDr9fjkUceQV5eHvbt2wd3d3eMGDECLVu2xE8//YQtW7agWbNmWLZsGY4cOYJmzZrVuH2MMW4B7qKiImzbtg1btmzB1KlTAQBNmzaFWq3GggULMGbMGJw6dcroQhQWFgaFQoH169ejX79+cHJygqurKyZMmIB3330XarUa3bp1Q05ODk6fPm3U3VFTb775Jtq2bYujR48iLi4OsbGxGDhwID799FO0atUKN27cwIYNGzBo0CAuy9CrVy8sWLAAzzzzDADA29sbbdq0wYoVKwSZvpYtWyItLQ2//fYbOnfujA0bNuD333+vtk1xcXFo1aoVRowYgTlz5iA/P18QZAHA3LlzERQUhIceeghKpRKrVq1CYGAgl+mqDV5eXvDx8cG3336LoKAgpKWlGXWf3b17Fy+++CLeeOMNPPHEEwgJCUHnzp0xYMAA7nx9+eWX+P3332W72RQKBd566y189NFHaNmyJZo1a4YpU6YgODgYAwcO5Pbr27cvBg0axGVZt2zZAsYYWrdujQsXLuCdd95BZGSkYHDDqlWr4Ofnh6ZNm+LkyZN48803MXDgQDz22GOCNly4cAF79uzBxo0bJds4Z84cPP7441AqlVizZg1mz56NlStXSv6d2ozJCiUii4q0a9cPey+x3v/dyW7kFtq7KcQMjWGYvxzxMH+9Xs/mzZvHWrduzRwdHZmfnx+Lj49nu3fvZoxVFHKPHDmSeXh4ME9PT/baa6+xiRMnsqioKJOP+eabb7KePXvKtsNQpG340Wg0rFWrVuzjjz8WFHsvX76chYeHM41Gw2JjY9mff/7JALDjx49z+3zwwQcsMDCQKRQKwTD/jz76iIWFhTFHR0fBMHZDkTb/GHfu3GEA2M6dO2XbLDXMnzHG4uPj2RNPPMEYqygQf/3111lwcDBzdHRkoaGhbPjw4SwtLY3b//fff2cA2Ndffy04XwBYSkqK4NjvvPMO8/HxYa6urmzo0KHs888/F0yPYBjmL5aamsoeeeQRplarWatWrdjmzZsFRdrffvst69ChA3NxcWHu7u6sb9++7NixqkEkI0aMMPn6SRXHS03dIG7ftm3bWJs2bZhGo2Ht27dnu3btErQrISGBtWvXTlDo/tlnnzFvb292/fp17phhYWGybWOs4n09ZcoUFhAQwDQaDevbty9LTU0V7BMWFsamTZvG/b5ixQrWvHlzplarWWBgIBs7dizLzc0V3Gf+/PksJCSEe09NnjyZlZSUGD3+pEmTWGhoKNPpdJLt6927N/Pw8GBarZbFxMSwjRs3mnw+tijSpsVqrUSL1RJShRarJfe7nj17onfv3pg+fbq9m0Jgm8VqqYuNEEIIqYG8vDxcvHgRGzZssHdTiA1RgEQIIYTUgIeHB65fv27vZhAbo3mQCCGEEEJEKEAihBBCCBGhAIkQQgghRIQCJEKIzdCgWEJIfWCLzyIKkAghNWZYLqGwsNDOLSGEkKrPIvFSLpagUWyEkBpTqVTw9PTkFtl0dnbm1uoihJC6whhDYWEhsrOz4enpWaOZtilAIoTYhGHBy+pWdyeEkNrm6enJfSZZiwIkQohNKBQKBAUFwd/fH2VlZfZuDiHkPuXo6GiTNdooQCKE2JRKpardBSQJIaQOUJE2IYQQQogIBUiEEEIIISIUIBFCCCGEiFANkpUMk1Dl5+fbuSWEEEIIMZfhul3dZJIUIFnp7t27AIDQ0FA7t4QQQgghlrp79y48PDxkb1cwWhvAKnq9Hjdu3ICbm5tNJ8TLz89HaGgorl27Bnd3d5sdlxijc1036DzXDTrPdYfOdd2orfPMGMPdu3cRHBwMpVK+0ogySFZSKpUICQmpteO7u7vTH14doXNdN+g81w06z3WHznXdqI3zbCpzZEBF2oQQQgghIhQgEUIIIYSIUIBUz2g0GkybNg0ajcbeTWn06FzXDTrPdYPOc92hc1037H2eqUibEEIIIUSEMkiEEEIIISIUIBFCCCGEiFCARAghhBAiQgESIYQQQogIBUj1zMKFCxEeHg6tVouYmBgcPnzY3k1qUPbs2YMBAwYgODgYCoUCa9euFdzOGMPUqVMRFBQEJycnxMXF4fz584J9bt++jeHDh8Pd3R2enp4YNWoU7t27V4fPov6bNWsWOnfuDDc3N/j7+2PgwIFITU0V7FNcXIyxY8fCx8cHrq6uGDx4MLKysgT7pKWloX///nB2doa/vz/eeecdlJeX1+VTqde+/vprtG/fnpsoLzY2Fps2beJup3NcO2bPng2FQoG33nqL20bn2jamT58OhUIh+ImMjORur0/nmQKkemTFihVITEzEtGnTcOzYMURFRSE+Ph7Z2dn2blqDUVBQgKioKCxcuFDy9k8//RRffPEFFi1ahEOHDsHFxQXx8fEoLi7m9hk+fDhOnz6Nbdu2Yf369dizZw9effXVunoKDcLu3bsxduxYHDx4ENu2bUNZWRkee+wxFBQUcPuMHz8e69atw6pVq7B7927cuHEDTz/9NHe7TqdD//79UVpaiv379+PHH3/E0qVLMXXqVHs8pXopJCQEs2fPRlJSEo4ePYo+ffrgqaeewunTpwHQOa4NR44cwTfffIP27dsLttO5tp0HH3wQGRkZ3M/evXu52+rVeWak3ujSpQsbO3Ys97tOp2PBwcFs1qxZdmxVwwWA/f7779zver2eBQYGsjlz5nDbcnNzmUajYb/++itjjLEzZ84wAOzIkSPcPps2bWIKhYKlp6fXWdsbmuzsbAaA7d69mzFWcV4dHR3ZqlWruH3Onj3LALADBw4wxhjbuHEjUyqVLDMzk9vn66+/Zu7u7qykpKRun0AD4uXlxb7//ns6x7Xg7t27rGXLlmzbtm2sZ8+e7M0332SM0fvZlqZNm8aioqIkb6tv55kySPVEaWkpkpKSEBcXx21TKpWIi4vDgQMH7NiyxuPy5cvIzMwUnGMPDw/ExMRw5/jAgQPw9PREp06duH3i4uKgVCpx6NChOm9zQ5GXlwcA8Pb2BgAkJSWhrKxMcK4jIyPRtGlTwblu164dAgICuH3i4+ORn5/PZUhIFZ1Oh99++w0FBQWIjY2lc1wLxo4di/79+wvOKUDvZ1s7f/48goOD0bx5cwwfPhxpaWkA6t95psVq64mbN29Cp9MJXnQACAgIQEpKip1a1bhkZmYCgOQ5NtyWmZkJf39/we0ODg7w9vbm9iFCer0eb731Frp164a2bdsCqDiParUanp6egn3F51rqtTDcRiqcPHkSsbGxKC4uhqurK37//Xc88MADSE5OpnNsQ7/99huOHTuGI0eOGN1G72fbiYmJwdKlS9G6dWtkZGRgxowZ6N69O06dOlXvzjMFSISQGhk7dixOnTolqCMgttO6dWskJycjLy8P//vf//D/7d1ZTJPpGgfwfxVaS2pB4IMSBURFFI2IoKSTMTipgniDxgvjEotrQIk7ibuOZMQYNS5zMU7iFnGJ0bjhEhGkRhMxAm4xYlCxXhhJlCoIUrXPXEz8zmnxzMmZKbZw/r/kS9rvfXn7fE978ad9m1qtVthsNl+X1aW8fPkSixcvRmlpKXr06OHrcrq0rKws9fawYcOQlpaG2NhYnDhxAnq93oeVtceP2PxEeHg4unfv3m63/uvXr2EymXxUVdfytY9/1WOTydRuU/znz5/x9u1bPg/fkJ+fj5KSEly7dg19+vRRz5tMJjidTjgcDrf5nr3+1nPxdYz+pNVqMWDAAKSkpKCoqAhJSUnYtWsXe+xFVVVVaGhowIgRIxAQEICAgADYbDbs3r0bAQEBiIyMZK87SEhICAYOHIi6ujq/e00zIPkJrVaLlJQUlJWVqedcLhfKyspgNpt9WFnXERcXB5PJ5Nbj9+/fo7KyUu2x2WyGw+FAVVWVOqe8vBwulwtpaWnfvWZ/JSLIz8/H6dOnUV5ejri4OLfxlJQUBAYGuvW6trYWdrvdrdcPHjxwC6SlpaUwGo1ITEz8PhfSCblcLrS1tbHHXmSxWPDgwQPcvXtXPVJTUzF9+nT1NnvdMZqbm/H06VNERUX532vaq1u+6R85fvy46HQ6OXjwoDx69Ejmz58vISEhbrv16a81NTVJTU2N1NTUCADZsWOH1NTUyIsXL0REZMuWLRISEiJnz56V+/fvS3Z2tsTFxUlra6u6xvjx4yU5OVkqKyvlxo0bEh8fL1OnTvXVJfmlvLw8CQ4OloqKCnn16pV6tLS0qHNyc3MlJiZGysvL5c6dO2I2m8VsNqvjnz9/lqFDh0pGRobcvXtXLl++LIqiyKpVq3xxSX5p5cqVYrPZ5Pnz53L//n1ZuXKlaDQauXLlioiwxx3p37/FJsJee8vy5culoqJCnj9/Ljdv3pSxY8dKeHi4NDQ0iIh/9ZkByc/s2bNHYmJiRKvVyqhRo+TWrVu+LqlTuXbtmgBod1itVhH586v+69atk8jISNHpdGKxWKS2ttZtjTdv3sjUqVPFYDCI0WiUWbNmSVNTkw+uxn99q8cA5MCBA+qc1tZWWbBggfTq1UuCgoJk0qRJ8urVK7d16uvrJSsrS/R6vYSHh8vy5cvl06dP3/lq/Nfs2bMlNjZWtFqtKIoiFotFDUci7HFH8gxI7LV3TJkyRaKiokSr1Urv3r1lypQpUldXp477U581IiLefU+KiIiIqHPjHiQiIiIiDwxIRERERB4YkIiIiIg8MCAREREReWBAIiIiIvLAgERERETkgQGJiIiIyAMDEhH93xszZgyWLFni6zKIyI8wIBFRp/CfQszBgwcREhLyXWupqKiARqNp96OaRNR1MCAREREReWBAIqIuIycnBxMnTsTPP/8MRVFgNBqRm5sLp9Opzvnw4QNmzpwJg8GAqKgobN++vd06hw8fRmpqKnr27AmTyYRp06apvx5eX1+Pn376CQDQq1cvaDQa5OTkAABcLheKiooQFxcHvV6PpKQknDx5Ul23sbER06dPh6Io0Ov1iI+Px4EDBzqwI0T0dwX4ugAiIm8qKytDjx49UFFRgfr6esyaNQthYWH45ZdfAAAFBQWw2Ww4e/YsIiIisHr1alRXV2P48OHqGp8+fUJhYSESEhLQ0NCAZcuWIScnBxcvXkR0dDROnTqFyZMno7a2FkajEXq9HgBQVFSE4uJi/Pbbb4iPj8f169cxY8YMKIqC9PR0rFu3Do8ePcKlS5cQHh6Ouro6tLa2+qJNRPRfMCARUZei1Wqxf/9+BAUFYciQIdi0aRMKCgpQWFiIlpYW7Nu3D8XFxbBYLACAQ4cOoU+fPm5rzJ49W73dr18/7N69GyNHjkRzczMMBgNCQ0MBABEREer+p7a2NmzevBlXr16F2WxW//bGjRvYu3cv0tPTYbfbkZycjNTUVABA3759O7gbRPR3MSARUZeSlJSEoKAg9b7ZbEZzczNevnwJh8MBp9OJtLQ0dTw0NBQJCQlua1RVVWHjxo24d+8eGhsb4XK5AAB2ux2JiYnffNy6ujq0tLRg3LhxbuedTieSk5MBAHl5eZg8eTKqq6uRkZGBiRMn4ocffvDKdRORdzEgEVGnYDQa8e7du3bnHQ4HgoODvfY4Hz58QGZmJjIzM3HkyBEoigK73Y7MzEy3vUyempubAQAXLlxA79693cZ0Oh0AICsrCy9evMDFixdRWloKi8WChQsXYtu2bV6rn4i8g5u0iahTSEhIQHV1dbvz1dXVGDhwoHr/3r17bvt6bt26BYPBgOjoaPTv3x+BgYGorKxUxxsbG/HkyRP1/uPHj/HmzRts2bIFo0ePxqBBg9QN2l9ptVoAwJcvX9RziYmJ0Ol0sNvtGDBggNsRHR2tzlMUBVarFcXFxdi5cyd+//33f9AVIuoofAeJiDqFvLw8/Prrr1i0aBHmzp0LnU6HCxcu4NixYzh//rw6z+l0Ys6cOVi7di3q6+uxYcMG5Ofno1u3bjAYDJgzZw4KCgoQFhaGiIgIrFmzBt26/et/xZiYGGi1WuzZswe5ubl4+PAhCgsL3WqJjY2FRqNBSUkJJkyYAL1ej549e2LFihVYunQpXC4XfvzxR7x79w43b96E0WiE1WrF+vXrkZKSgiFDhqCtrQ0lJSUYPHjwd+shEf0PhIiok7h9+7aMGzdOFEWR4OBgSUtLk9OnT6vjVqtVsrOzZf369RIWFiYGg0HmzZsnHz9+VOc0NTXJjBkzJCgoSCIjI2Xr1q2Snp4uixcvVuccPXpU+vbtKzqdTsxms5w7d04ASE1NjTpn06ZNYjKZRKPRiNVqFRERl8slO3fulISEBAkMDBRFUSQzM1NsNpuIiBQWFsrgwYNFr9dLaGioZGdny7NnzzqyZUT0N2lERHwd0oiIvCEnJwcOhwNnzpzxdSlE1MlxDxIRERGRBwYkIiIiIg/8iI2IiIjIA99BIiIiIvLAgERERETkgQGJiIiIyAMDEhEREZEHBiQiIiIiDwxIRERERB4YkIiIiIg8MCAREREReWBAIiIiIvLwB6tp7ma7C85IAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "reward_history = np.array(q_env.reward_history)\n",
+    "mean_rewards = np.mean(reward_history, axis=-1)\n",
+    "max_mean = int(np.max(mean_rewards) * 1e4) / 1e4\n",
+    "\n",
+    "plt.plot(mean_rewards, label=f'Mean Batch Rewards, max: {max_mean}')\n",
+    "plt.xlabel('Updates')\n",
+    "plt.ylabel('Reward')\n",
+    "plt.title('CX Learning Curve')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cqt_env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/template_configurations/qiskit/pulse_config.py
+++ b/template_configurations/qiskit/pulse_config.py
@@ -27,7 +27,7 @@ from dynamics_config import dynamics_backend
 from typing import List, Sequence
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
-config_file_name = "q_env_config.yml"
+config_file_name = "q_env_pulse_config.yml"
 config_file_address = os.path.join(current_dir, config_file_name)
 
 

--- a/template_configurations/qiskit/q_env_config.py
+++ b/template_configurations/qiskit/q_env_config.py
@@ -26,7 +26,7 @@ from context_aware_quantum_environment import ContextAwareQuantumEnvironment
 from dynamics_config import dynamics_backend
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
-config_file_name = "q_env_config.yml"
+config_file_name = "q_env_gate_config.yml"
 config_file_address = os.path.join(current_dir, config_file_name)
 
 
@@ -45,6 +45,7 @@ def apply_parametrized_circuit(
     parametrized_qc = QuantumCircuit(q_reg)
     my_qc = QuantumCircuit(q_reg, name="custom_cx")
     optimal_params = np.pi * np.array([0.0, 0.0, 0.5, 0.5, -0.5, 0.5, -0.5])
+    # optimal_params = np.pi * np.zeros(7)
 
     my_qc.u(
         optimal_params[0] + params[0],
@@ -58,6 +59,7 @@ def apply_parametrized_circuit(
         optimal_params[5] + params[5],
         q_reg[1],
     )
+
     my_qc.rzx(optimal_params[6] + params[6], q_reg[0], q_reg[1])
     # my_qc.u(np.pi *params[0], np.pi *params[1], np.pi *params[2], 0)
     # my_qc.u(np.pi *params[3], np.pi *params[4], np.pi *params[5], 1)

--- a/template_configurations/qiskit/q_env_config.py
+++ b/template_configurations/qiskit/q_env_config.py
@@ -18,6 +18,7 @@ from custom_jax_sim import JaxSolver
 from qiskit_ibm_runtime import QiskitRuntimeService, IBMBackend as RuntimeBackend
 from qiskit_ibm_runtime.fake_provider import FakeProvider
 from qiskit.providers import BackendV1, BackendV2
+from qiskit.providers.fake_provider import FakeJakartaV2
 from qiskit_experiments.calibration_management import Calibrations
 from qconfig import QiskitConfig, QEnvConfig
 from quantumenvironment import QuantumEnvironment
@@ -116,7 +117,8 @@ def get_backend(
             _, _ = perform_standard_calibrations(backend)
         else:
             # TODO: Add here your custom backend
-            pass
+            # For now use FakeJakartaV2 as a safe working custom backend
+            backend = FakeJakartaV2()
 
     return backend
 

--- a/template_configurations/qiskit/q_env_gate_config.yml
+++ b/template_configurations/qiskit/q_env_gate_config.yml
@@ -1,6 +1,6 @@
 SERVICE: # Relevant only when using the Qiskit runtime service
   CHANNEL: "ibm_quantum"
-  INSTANCE: 'ibm-q-nus/default/default'
+  INSTANCE: "ibm-q-nus/default/default"
 
 RUNTIME_OPTIONS: # Relevant only when using the Qiskit runtime service
   optimization_level: 3
@@ -17,7 +17,7 @@ RUNTIME_OPTIONS: # Relevant only when using the Qiskit runtime service
     noise_amplifier: null
     noise_factors: null
   environment:
-    log_level: 'WARNING'
+    log_level: "WARNING"
     job_tags: null
   simulator:
     seed_simulator: 100
@@ -25,37 +25,28 @@ RUNTIME_OPTIONS: # Relevant only when using the Qiskit runtime service
     basis_gates: null
 
 BACKEND: # Backend configuration (If all set to None, the user needs to specify its own backend in q_env_config.py's get_backend() function)
-  REAL_BACKEND: null  # True: real or False: fake Aer backend
-  NAME: null  # Name of the backend
+  REAL_BACKEND: null # True: real or False: fake Aer backend
+  NAME: null # Name of the backend
   DYNAMICS: # Use a DynamicsBackend (if fields above are not null, build a DynamicsBackend.from_backend() with the specified backend)
-    USE_DYNAMICS: True # Whether to use a DynamicsBackend
-    PHYSICAL_QUBITS: null  # Number of qubits characterizing the environment (i.e. the full quantum circuit dimension)
+    USE_DYNAMICS: null # Whether to use a DynamicsBackend
+    PHYSICAL_QUBITS: null # Number of qubits characterizing the environment (i.e. the full quantum circuit dimension)
 
 TARGET: # Target Gate configuration
-  GATE: "X"
+  GATE: "CX"
   # STATE: "0" # Target state (if GATE is null)
-  PHYSICAL_QUBITS: [ 0 ]
+  PHYSICAL_QUBITS: [0, 1]
 
 ENV: # Environment configuration
   SAMPLING_PAULIS: 100 # Number of Pauli strings to sample
   N_SHOTS: 1
-  C_FACTOR: 1. # Cost factor for the reward function
-  N_ACTIONS: 2 # Action vector length
-  BATCH_SIZE: 96 # Number of actions to evaluate per policy iteration
+  C_FACTOR: 0.25 # Cost factor for the reward function
+  N_ACTIONS: 7 # Action vector length
+  BATCH_SIZE: 256 # Number of actions to evaluate per policy iteration
   ACTION_SPACE:
-    LOW: [ -1., -1. ]
-    HIGH: [ 1., 1. ]
-  OBSERVATION_SPACE: 1  # Shape of the observation space
-  BENCHMARK_CYCLE: 10  # Number of steps between two fidelity benchmarks
+    LOW: [-1., -1., -1., -1., -1., -1., -1.]
+    HIGH: [1., 1., 1., 1., 1., 1., 1.]
+  OBSERVATION_SPACE: 1 # Shape of the observation space
+  BENCHMARK_CYCLE: 1000 # Number of steps between two fidelity benchmarks
   SEED: 100
-  CHECK_ON_EXP: True # Whether to perform fidelity benchmarking with tomographic experiments or just using simulation
-
-
-
-
-
-
-
-
-
-
+  CHECK_ON_EXP: False # Whether to perform fidelity benchmarking with tomographic experiments or just using simulation
+  TRAINING_WITH_CAL: True

--- a/template_configurations/qiskit/q_env_pulse_config.yml
+++ b/template_configurations/qiskit/q_env_pulse_config.yml
@@ -1,0 +1,52 @@
+SERVICE: # Relevant only when using the Qiskit runtime service
+  CHANNEL: "ibm_quantum"
+  INSTANCE: "ibm-q-nus/default/default"
+
+RUNTIME_OPTIONS: # Relevant only when using the Qiskit runtime service
+  optimization_level: 3
+  resilience_level: null
+  max_execution_time: null
+  transpilation:
+    skip_transpilation: False
+    initial_layout: null
+    approximation_degree: null
+    layout_method: null
+    routing_method: null
+  resilience:
+    extrapolator: null
+    noise_amplifier: null
+    noise_factors: null
+  environment:
+    log_level: "WARNING"
+    job_tags: null
+  simulator:
+    seed_simulator: 100
+    coupling_map: null
+    basis_gates: null
+
+BACKEND: # Backend configuration (If all set to None, the user needs to specify its own backend in q_env_config.py's get_backend() function)
+  REAL_BACKEND: null # True: real or False: fake Aer backend
+  NAME: null # Name of the backend
+  DYNAMICS: # Use a DynamicsBackend (if fields above are not null, build a DynamicsBackend.from_backend() with the specified backend)
+    USE_DYNAMICS: True # Whether to use a DynamicsBackend
+    PHYSICAL_QUBITS: null # Number of qubits characterizing the environment (i.e. the full quantum circuit dimension)
+
+TARGET: # Target Gate configuration
+  GATE: "X"
+  # STATE: "0" # Target state (if GATE is null)
+  PHYSICAL_QUBITS: [0]
+
+ENV: # Environment configuration
+  SAMPLING_PAULIS: 100 # Number of Pauli strings to sample
+  N_SHOTS: 1
+  C_FACTOR: 0.5 # Cost factor for the reward function
+  N_ACTIONS: 2 # Action vector length
+  BATCH_SIZE: 256 # Number of actions to evaluate per policy iteration
+  ACTION_SPACE:
+    LOW: [-1., -1.]
+    HIGH: [1., 1.]
+  OBSERVATION_SPACE: 1 # Shape of the observation space
+  BENCHMARK_CYCLE: 1000 # Number of steps between two fidelity benchmarks
+  SEED: 100
+  CHECK_ON_EXP: False # Whether to perform fidelity benchmarking with tomographic experiments or just using simulation
+  TRAINING_WITH_CAL: True


### PR DESCRIPTION
Many modifications in here:
1. helper_functions is updated to remove the dtype warning Gymnasium raises
2. ppo is updated to handle the rewards now properly (the rewards wasn't being updated earlier after stepping) and there are some more debugging statements to track learning
3. qconfig, specifically QEnvConfig has a new boolean argument training_with_cal
4. quantumenvironment now does a safety check that the c_factor is calibrated appropriately, and this check is toggled by the training_with_cal var
5. agent_config.yml now has some better params for learning, I would recommend sticking with these as they're stable during testing
6. added a q_env_pulse_config and q_env_gate_config for easier tracking, otherwise parameters get mixed up when moving from one config to another
7. The learning results are shown in the gate_level_learning notebook!